### PR TITLE
Fix #126

### DIFF
--- a/julearn/utils/logging.py
+++ b/julearn/utils/logging.py
@@ -43,7 +43,7 @@ def get_versions(sys):
     for name, module in sys.modules.items():
         if '.' in name:
             continue
-        if '_curses' == name:
+        if name in ['_curses', '_glmnet']:
             continue
         module_version = LooseVersion(getattr(module, '__version__', None))
         module_version = getattr(module_version, 'vstring', None)


### PR DESCRIPTION
Package GLMNET was importing 2 modules, one which has a wrong format for the `__version__` attribute (`_glmnet`).