### PR TITLE
Solve #122

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -49,5 +49,7 @@ Bugs
 
 - Raise error message when columns in the dataframe are nos strings (:gh:`77` by `Fede Raimondo`_).
 
+- Fix Bug in the transformer wrapper implementation (:gh:`122` by `Sami Hamdan`_).
+
 API changes
 ~~~~~~~~~~~

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -3,6 +3,7 @@
 # License: AGPL
 from sklearn.pipeline import Pipeline
 from sklearn.base import BaseEstimator, clone
+from sklearn.utils import Bunch
 
 from . transformers import DataFrameWrapTransformer, DropColumns
 from . utils import raise_error
@@ -258,11 +259,25 @@ class ExtendedDataFramePipeline(BaseEstimator):
 
     @ property
     def named_steps(self):
-        return self.dataframe_pipeline.named_steps
+        steps = self.dataframe_pipeline.named_steps
+        if isinstance(steps, Bunch):
+            return Bunch(**
+                         {name: self._get_wrapped_step(step)
+                          for name, step in steps.items()
+                          })
+        else:
+            return self._get_wrapped_step(steps)
 
     @ property
     def named_confound_steps(self):
-        return self.confound_dataframe_pipeline.named_steps
+        steps = self.confound_dataframe_pipeline.named_steps
+        if isinstance(steps, Bunch):
+            return Bunch(**
+                         {name: self._get_wrapped_step(step)
+                          for name, step in steps.items()
+                          })
+        else:
+            return self._get_wrapped_step(steps)
 
     def __getitem__(self, ind):
         if not isinstance(ind, str):
@@ -274,7 +289,7 @@ class ExtendedDataFramePipeline(BaseEstimator):
             element = self.y_transformer
         else:
             element = self.dataframe_pipeline[ind]
-        return element
+        return self._get_wrapped_step(element)
 
     def __repr__(self):
         preprocess_X = clone(self.dataframe_pipeline).steps
@@ -368,6 +383,27 @@ class ExtendedDataFramePipeline(BaseEstimator):
                    )
 
         return X_trans
+
+    @staticmethod
+    def _get_wrapped_step(step):
+        """returns wrapped transformer if a DataFrameWrapTransformer is
+        provided.
+
+        Parameters
+        ----------
+        step : obj
+            A step of a DataFramePipeline
+
+        Returns
+        -------
+        step
+            step if not wrapped else wrapped transformer
+        """
+        step = (step.transformer
+                if isinstance(step, DataFrameWrapTransformer)
+                else step
+                )
+        return step
 
 
 def _create_extended_pipeline(

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -260,24 +260,18 @@ class ExtendedDataFramePipeline(BaseEstimator):
     @ property
     def named_steps(self):
         steps = self.dataframe_pipeline.named_steps
-        if isinstance(steps, Bunch):
-            return Bunch(**
-                         {name: self._get_wrapped_step(step)
-                          for name, step in steps.items()
-                          })
-        else:
-            return self._get_wrapped_step(steps)
+        return Bunch(**
+                     {name: self._get_wrapped_step(step)
+                         for name, step in steps.items()
+                      })
 
     @ property
     def named_confound_steps(self):
         steps = self.confound_dataframe_pipeline.named_steps
-        if isinstance(steps, Bunch):
-            return Bunch(**
-                         {name: self._get_wrapped_step(step)
-                          for name, step in steps.items()
-                          })
-        else:
-            return self._get_wrapped_step(steps)
+        return Bunch(**
+                     {name: self._get_wrapped_step(step)
+                         for name, step in steps.items()
+                      })
 
     def __getitem__(self, ind):
         if not isinstance(ind, str):

--- a/julearn/tests/test_pipeline.py
+++ b/julearn/tests/test_pipeline.py
@@ -373,9 +373,18 @@ def test_ExtendedDataFramePipeline___rpr__():
     extended_pipe.__repr__()
 
 
-def test_get_wrapped_transformer_params():
+def test_dataframe_pipeline_get_wrapped_transformer_params():
     steps = [('zscore', StandardScaler(with_mean=False))]
 
     my_pipe = create_dataframe_pipeline(steps)
     my_pipe.fit(X)
     assert my_pipe['zscore'].with_mean is False
+
+
+def test_extended_pipeline_get_wrapped_transformer_params():
+    steps = [('zscore', StandardScaler(with_mean=False))]
+
+    my_pipe = create_dataframe_pipeline(steps)
+    extended_pipe = ExtendedDataFramePipeline(my_pipe)
+    extended_pipe.fit(X)
+    assert extended_pipe['zscore'].with_mean is False

--- a/julearn/tests/test_pipeline.py
+++ b/julearn/tests/test_pipeline.py
@@ -373,14 +373,6 @@ def test_ExtendedDataFramePipeline___rpr__():
     extended_pipe.__repr__()
 
 
-def test_dataframe_pipeline_get_wrapped_transformer_params():
-    steps = [('zscore', StandardScaler(with_mean=False))]
-
-    my_pipe = create_dataframe_pipeline(steps)
-    my_pipe.fit(X)
-    assert my_pipe['zscore'].with_mean is False
-
-
 def test_extended_pipeline_get_wrapped_transformer_params():
     steps = [('zscore', StandardScaler(with_mean=False))]
 

--- a/julearn/tests/test_pipeline.py
+++ b/julearn/tests/test_pipeline.py
@@ -126,7 +126,9 @@ def test_access_steps_ExtendedDataFramePipeline():
             == (my_pipe
                 .confound_dataframe_pipeline
                 .named_steps
-                .zscore)
+                .zscore
+                .transformer
+                )
             )
 
     assert (my_pipe.named_steps.pca
@@ -134,7 +136,9 @@ def test_access_steps_ExtendedDataFramePipeline():
             == (my_pipe
                 .dataframe_pipeline
                 .named_steps
-                .pca)
+                .pca
+                .transformer
+                )
             )
 
     assert (my_pipe.named_steps.lr

--- a/julearn/tests/test_pipeline.py
+++ b/julearn/tests/test_pipeline.py
@@ -371,3 +371,11 @@ def test_ExtendedDataFramePipeline___rpr__():
         categorical_features=None
     )
     extended_pipe.__repr__()
+
+
+def test_get_wrapped_transformer_params():
+    steps = [('zscore', StandardScaler(with_mean=False))]
+
+    my_pipe = create_dataframe_pipeline(steps)
+    my_pipe.fit(X)
+    assert my_pipe['zscore'].with_mean is False


### PR DESCRIPTION
Here, we want to go for a simpler attempt at solving #122.
Instead of making wrapped params part of wrapper, we just change the getters for `ExtendedPipeline` so that it returns the wrapped object iteself