### PR TITLE
[WIP] Make API compatible between julearn and scikit-learn pipelines 

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -49,5 +49,7 @@ Bugs
 
 - Raise error message when columns in the dataframe are nos strings (:gh:`77` by `Fede Raimondo`_).
 
+- Fix groups not properly applied (:gh:141` by `Fede Raimondo`_ and `Sami Hamdan`_).
+
 API changes
 ~~~~~~~~~~~

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -195,7 +195,9 @@ def run_cross_validation(
 
     scores = cross_validate(pipeline, df_X_conf, y, cv=cv_outer,
                             scoring=scorer, groups=df_groups,
-                            return_estimator=cv_return_estimator)
+                            return_estimator=cv_return_estimator,
+                            fit_params=dict(groups=df_groups)
+                            )
 
     n_repeats = getattr(cv_outer, 'n_repeats', 1)
     n_folds = len(scores['fit_time']) // n_repeats

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -208,7 +208,7 @@ def run_cross_validation(
 
     out = pd.DataFrame(scores)
     if return_estimator in ['final', 'all']:
-        pipeline.fit(df_X_conf, y)
+        pipeline.fit(df_X_conf, y, groups=df_groups)
         out = out, pipeline
 
     return out

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -196,7 +196,11 @@ def run_cross_validation(
     scores = cross_validate(pipeline, df_X_conf, y, cv=cv_outer,
                             scoring=scorer, groups=df_groups,
                             return_estimator=cv_return_estimator,
-                            fit_params=dict(groups=df_groups)
+                            fit_params=dict(
+                                groups=df_groups,
+                                confounds=confounds,
+                                categorical_features=None
+                            )
                             )
 
     n_repeats = getattr(cv_outer, 'n_repeats', 1)
@@ -210,7 +214,10 @@ def run_cross_validation(
 
     out = pd.DataFrame(scores)
     if return_estimator in ['final', 'all']:
-        pipeline.fit(df_X_conf, y, groups=df_groups)
+        pipeline.fit(df_X_conf, y,
+                     groups=df_groups,
+                     confounds=confounds,
+                     categorical_features=None)
         out = out, pipeline
 
     return out
@@ -308,8 +315,8 @@ def create_pipeline(
     pipeline = _create_extended_pipeline(preprocess_X,
                                          preprocess_y,
                                          preprocess_confounds,
-                                         model_tuple, confounds,
-                                         categorical_features=None)
+                                         model_tuple,
+                                         )
 
     if model_params is not None:
         pipeline = prepare_model_params(model_params, pipeline)

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -163,9 +163,6 @@ def run_cross_validation(
         logger.info(f'Using default CV')
         cv = 'repeat:5_nfolds:5'
 
-    # if scoring is None:
-    #     scoring = 'accuracy'
-
     # Interpret the input data and prepare it to be used with the library
     df_X_conf, y, df_groups, _ = prepare_input_data(
         X=X, y=y, confounds=confounds, df=data, pos_labels=pos_labels,

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -109,7 +109,7 @@ class ExtendedDataFramePipeline(BaseEstimator):
         self.confounds = confounds
         self.categorical_features = categorical_features
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, **fit_params):
         self.dataframe_pipeline = clone(self.dataframe_pipeline)
         self.confound_dataframe_pipeline = (
             None

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -3,7 +3,6 @@
 # License: AGPL
 from sklearn.pipeline import Pipeline
 from sklearn.base import BaseEstimator, clone
-from sklearn.utils.validation import check_is_fitted
 
 from . transformers import DataFrameWrapTransformer, DropColumns
 from . utils import raise_error

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -172,6 +172,14 @@ class ExtendedDataFramePipeline(BaseEstimator):
         else:
             return self.confound_dataframe_pipeline.transform(X)
 
+    def fit_transform(self, X, y=None, **params):
+        self.fit(X, y, **params)
+        return self.transform(X)
+
+    def fit_predict(self, X, y=None, **params):
+        self.fit(X, y, **params)
+        return self.predict(X)
+
     def preprocess(self, X, y, until=None, return_trans_column_type=False):
         """
 
@@ -225,10 +233,6 @@ class ExtendedDataFramePipeline(BaseEstimator):
         if not return_trans_column_type:
             X_trans = self._remove_column_types(X_trans)
         return X_trans, y_trans
-
-    def fit_transform(self, X, y=None, **fit_params):
-        self.fit(X, y, **fit_params)
-        return self.transform(X)
 
     def set_params(self, **params):
         super().set_params(**{self._rename_param(param): val

--- a/julearn/pipeline.py
+++ b/julearn/pipeline.py
@@ -60,7 +60,7 @@ class ExtendedDataFramePipeline(BaseEstimator):
             be considered the ground truth to score against.
             Note: if you want to score this pipeline with an external function.
             You have to consider that the scorer needs to be an
-             extended_scorer.
+            extended_scorer.
 
         * Handling confounds:
             Adds the confound as type to columns.

--- a/julearn/tests/test_api.py
+++ b/julearn/tests/test_api.py
@@ -278,7 +278,7 @@ def test_tune_hyperparam():
     actual, actual_estimator = run_cross_validation(
         X=X, y=y, data=df_iris, model='svm', preprocess_X='zscore',
         model_params=model_params, cv=cv_outer, scoring=[scoring],
-        return_estimator='final')
+        groups='groups', return_estimator='final')
 
 
 def test_consistency():

--- a/julearn/tests/test_api.py
+++ b/julearn/tests/test_api.py
@@ -267,6 +267,19 @@ def test_tune_hyperparam():
     clf2 = clone(gs).fit(sk_X, sk_y).best_estimator_.steps[-1][1]
     compare_models(clf1, clf2)
 
+    # Now test using group cv as inner CV scheme
+    cv_outer = RepeatedKFold(n_splits=2, n_repeats=1)
+    cv_inner = GroupKFold(n_splits=2)
+    df_iris['groups'] = np.digitize(
+        df_iris['sepal_length'],
+        bins=np.histogram(df_iris['sepal_length'], bins=20)[1])
+
+    model_params = {'svm__C': [0.01, 0.001], 'cv': cv_inner}
+    actual, actual_estimator = run_cross_validation(
+        X=X, y=y, data=df_iris, model='svm', preprocess_X='zscore',
+        model_params=model_params, cv=cv_outer, scoring=[scoring],
+        return_estimator='final')
+
 
 def test_consistency():
     """Test for consistency in the parameters"""

--- a/julearn/tests/test_pipeline.py
+++ b/julearn/tests/test_pipeline.py
@@ -73,8 +73,8 @@ def test_ExtendedDataFramePipeline_transform_with_categorical():
     sklearn_pipe = make_pipeline(StandardScaler())
 
     my_pipe = create_dataframe_pipeline(steps)
-    my_pipe = ExtendedDataFramePipeline(my_pipe, categorical_features=['C'])
-    X_trans = my_pipe.fit_transform(X)
+    my_pipe = ExtendedDataFramePipeline(my_pipe)
+    X_trans = my_pipe.fit_transform(X, categorical_features=['C'])
     X_trans_sklearn = sklearn_pipe.fit_transform(X.loc[:, ['A', 'B']])
 
     assert_array_equal(X_trans.loc[:, ['A', 'B']].values, X_trans_sklearn)
@@ -95,11 +95,9 @@ def test_create_extended_dataframe_transformer():
         preprocess_transformer_target=y_transformer,
         preprocess_steps_confounds=conf_steps,
         model=model,
-        confounds='B',
-        categorical_features=None
     )
 
-    extended_pipe.fit(X.iloc[:, :-1], X.C)
+    extended_pipe.fit(X.iloc[:, :-1], X.C, confounds='B',)
     extended_pipe.predict(X.iloc[:, :-1])
     score = extended_pipe.score(X.iloc[:, :-1], X.C)
     assert score is not np.nan
@@ -119,7 +117,7 @@ def test_access_steps_ExtendedDataFramePipeline():
 
     my_pipe = ExtendedDataFramePipeline(
         my_pipe, y_transformer=y_transformer,
-        confound_dataframe_pipeline=my_confound_pipe, confounds=['B'])
+        confound_dataframe_pipeline=my_confound_pipe)
 
     assert (my_pipe.named_confound_steps.zscore
             == my_pipe['confound__zscore']
@@ -171,10 +169,10 @@ def test_preprocess_all_ExtendedDataFramePipeline():
         dataframe_pipeline=steps_pipe,
         y_transformer=y_transformer,
         confound_dataframe_pipeline=confounds_pipe,
-        confounds=['B'])
+    )
 
     np.random.seed(42)
-    extended_pipe.fit(X, y)
+    extended_pipe.fit(X, y, confounds=['B'])
 
     np.random.seed(42)
     X_recoded = extended_pipe._recode_columns(X.copy())
@@ -211,10 +209,10 @@ def test_preprocess_until_ExtendedDataFramePipeline():
         dataframe_pipeline=steps_pipe,
         y_transformer=y_transformer,
         confound_dataframe_pipeline=confounds_pipe,
-        confounds=['B'])
+    )
 
     np.random.seed(42)
-    extended_pipe.fit(X, y)
+    extended_pipe.fit(X, y, confounds=['B'])
 
     np.random.seed(42)
     X_trans = extended_pipe._recode_columns(X.copy())
@@ -285,10 +283,10 @@ def test_remove_column_types_ExtendedDataFramePipe():
     extended_pipe = ExtendedDataFramePipeline(
         dataframe_pipeline=steps_pipe,
         y_transformer=y_transformer,
-        confound_dataframe_pipeline=confounds_pipe,
-        confounds=['B'])
+        confound_dataframe_pipeline=confounds_pipe
+    )
 
-    extended_pipe.fit(X, y)
+    extended_pipe.fit(X, y, confounds=['B'])
     X_removed = extended_pipe._remove_column_types(X_with_types)
     assert (X_removed.columns == list('abcdef')).all()
 
@@ -313,8 +311,6 @@ def test_create_exteneded_pipeline_confound_removal():
         preprocess_transformer_target=y_transformer,
         preprocess_steps_confounds=conf_steps,
         model=model,
-        confounds='B',
-        categorical_features=None
     )
 
     extended_pipe_keep_confound = _create_extended_pipeline(
@@ -322,17 +318,15 @@ def test_create_exteneded_pipeline_confound_removal():
         preprocess_transformer_target=y_transformer,
         preprocess_steps_confounds=conf_steps,
         model=model,
-        confounds='B',
-        categorical_features=None
     )
     np.random.seed(4242)
     pred = (extended_pipe
-            .fit(X.iloc[:, :-1], X.C)
+            .fit(X.iloc[:, :-1], X.C, confounds='B')
             .predict(X.iloc[:, :-1]))
 
     np.random.seed(4242)
     pred_keep = (extended_pipe_keep_confound
-                 .fit(X.iloc[:, :-1], X.C)
+                 .fit(X.iloc[:, :-1], X.C, confounds='B',)
                  .predict(X.iloc[:, :-1]))
 
     assert_array_equal(pred, pred_keep)
@@ -349,8 +343,6 @@ def test_tune_params():
         preprocess_steps_confounds=[('zscore', get_transformer('zscore'))],
         preprocess_transformer_target=get_transformer('zscore', target=True),
         model=('svm', SVR()),
-        confounds=None,
-        categorical_features=None
     )
 
     extended_pipe.set_params(**params)
@@ -367,7 +359,5 @@ def test_ExtendedDataFramePipeline___rpr__():
         preprocess_steps_confounds=[('zscore', get_transformer('zscore'))],
         preprocess_transformer_target=get_transformer('zscore', target=True),
         model=('svm', SVR()),
-        confounds=None,
-        categorical_features=None
     )
     extended_pipe.__repr__()

--- a/julearn/tests/test_prepare.py
+++ b/julearn/tests/test_prepare.py
@@ -412,8 +412,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     pipeline = prepare_model_params(model_params, pipeline)
     assert pipeline['svm'].get_params()['kernel'] == 'linear'
 
@@ -425,8 +424,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     pipeline = prepare_model_params(model_params, pipeline)
     assert pipeline.cv.n_splits == 5  # sklearn cv default
     assert isinstance(pipeline, GridSearchCV)
@@ -447,8 +445,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     pipeline = prepare_model_params(model_params, pipeline)
 
     assert pipeline.cv.n_splits == 5
@@ -465,8 +462,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     with pytest.warns(RuntimeWarning, match='search CV was specified'):
         pipeline = prepare_model_params(model_params, pipeline)
 
@@ -477,8 +473,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     with pytest.warns(RuntimeWarning, match='search scoring was specified'):
         pipeline = prepare_model_params(model_params, pipeline)
 
@@ -489,8 +484,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     with pytest.warns(RuntimeWarning, match='search method was specified'):
         pipeline = prepare_model_params(model_params, pipeline)
 
@@ -501,8 +495,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     with pytest.raises(ValueError, match='not a valid julearn searcher'):
         pipeline = prepare_model_params(model_params, pipeline)
 
@@ -513,8 +506,7 @@ def test_prepare_model_params():
         preprocess_transformer_target=None,
         preprocess_steps_confounds=None,
         model=model,
-        confounds=None,
-        categorical_features=None)
+    )
     with pytest.warns(RuntimeWarning,
                       match=f'{model_params["search"]} is not'
                       ' a registered searcher.'):
@@ -653,8 +645,7 @@ def test__prepare_hyperparams():
             preprocess_transformer_target=None,
             preprocess_steps_confounds=None,
             model=model,
-            confounds=None,
-            categorical_features=None)
+        )
 
         to_tune = _prepare_hyperparams(param_grid, pipeline)
         needs_tuning = len(to_tune) > 0


### PR DESCRIPTION
Scikit-learn's pipeline allows `fit_params` in `fit`, `fit_transform` and `fit_predict` at least. We need to allow that.