### PR TITLE
ADD BaseEstimator to TargetConfoundRemover #151

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -19,6 +19,9 @@ Enhancements
 Bugs
 ~~~~
 
+
+- ADD BaseEstimator to ConfoundRemoval for Target  (:gh:`151` by `Sami Hamdan`_).
+
 API changes
 ~~~~~~~~~~~
 

--- a/julearn/transformers/confounds.py
+++ b/julearn/transformers/confounds.py
@@ -183,7 +183,7 @@ class DataFrameConfoundRemover(BaseEstimator, TransformerMixin):
         return residuals
 
 
-class TargetConfoundRemover(TransformerMixin):
+class TargetConfoundRemover(BaseEstimator, TransformerMixin):
 
     def __init__(self,
                  model_confound=None,


### PR DESCRIPTION
I added the BaseEstimator to the TargetTransformWrapper not the  TargetConfoundRemover
Here, I want to add it to the TargetConfoundRemover as I wanted before