### PR TITLE
Fix ci, use latest codespell from pip

### DIFF
--- a/examples/advanced/run_return_confounds.py
+++ b/examples/advanced/run_return_confounds.py
@@ -17,7 +17,7 @@ will discuss the options you have.
 from sklearn.datasets import load_diabetes  # to load data
 from julearn.transformers import ChangeColumnTypes
 from julearn import run_cross_validation
-
+import warnings
 
 # load in the data
 df_features, target = load_diabetes(return_X_y=True, as_frame=True)
@@ -53,11 +53,13 @@ data['target'] = target
 # a linear regression.
 #
 feature_names = list(df_features.drop(columns='sex').columns)
-scores, model = run_cross_validation(
-    X=feature_names, y='target', data=data,
-    confounds='sex', model='linreg', problem_type='regression',
-    preprocess_X=['remove_confound', 'pca'],
-    return_estimator='final')
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", lineno=443)
+    scores, model = run_cross_validation(
+        X=feature_names, y='target', data=data,
+        confounds='sex', model='linreg', problem_type='regression',
+        preprocess_X=['remove_confound', 'pca'],
+        return_estimator='final')
 
 ###############################################################################
 # We can use the `preprocess` method of the `.ExtendedDataFramePipeline`

--- a/julearn/model_selection/available_searchers.py
+++ b/julearn/model_selection/available_searchers.py
@@ -14,12 +14,12 @@ _available_searchers_reset = deepcopy(_available_searchers)
 
 
 def list_searchers():
-    """ List all available seraching algorithms
+    """ List all available searching algorithms
 
     Returns
     -------
     out : list(str)
-        A list of all available seracher names.
+        A list of all available searcher names.
     """
     return list(_available_searchers)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ pytest-cov
 seaborn
 codecov
 deslib
-https://github.com/codespell-project/codespell/archive/master.zip
+codespell


### PR DESCRIPTION
Use codespell from pip, not from master. 

This will fix the issue that some CI will not pass after codespell is updated. It will only change due to new codespell releases, which will not be as often as commits to the repo.