### PR TITLE
fix name __cls__.lower() bug

### DIFF
--- a/julearn/pipeline/pipeline.py
+++ b/julearn/pipeline/pipeline.py
@@ -122,7 +122,9 @@ class PipelineCreator:  # Pipeline creator
         apply_to = ColumnTypes(apply_to)
         self.validate_step(step, apply_to)
         if name is None:
-            name = step if isinstance(step, str) else step.__cls__.lower()
+            name = step if isinstance(
+                step, str
+            ) else step.__class__.__name__.lower()
             name = self._ensure_name(name)
         logger.info(f"Adding step {name} that applies to {apply_to}")
         params_to_set = dict()


### PR DESCRIPTION
The PipelineCreator seems to fail when using a scikitlearn estimator object.
The simple example:

```
from julearn.pipeline import PipelineCreator
from sklearn.kernel_ridge import KernelRidge

creator = PipelineCreator(problem_type="regression", apply_to="*").add(
    KernelRidge()
)
```

results in:
```
Traceback (most recent call last):
  File "cls_bug.py", line 4, in <module>
    creator = PipelineCreator(problem_type="regression", apply_to="*").add(
  File "/home/leonard/projects/julearn_hackathon/julearn/julearn/pipeline/pipeline.py", line 125, in add
    name = step if isinstance(step, str) else step.__cls__.lower()
AttributeError: 'KernelRidge' object has no attribute '__cls__'
```

I believe this is intended to be the __class__.__name__ attribute?
With the applied change it works.