### PR TITLE
[ENH] Allow list of hyperparameter options for tuning

### DIFF
--- a/docs/changes/newsfragments/47.feature
+++ b/docs/changes/newsfragments/47.feature
@@ -1,0 +1,1 @@
+Add support for multiple grids in hyperparameter tuning by `Fede Raimondo`_

--- a/examples/03_complex_models/run_hyperparameter_multiple_grids.py
+++ b/examples/03_complex_models/run_hyperparameter_multiple_grids.py
@@ -1,4 +1,3 @@
-# %%
 """
 Tuning Multiple Hyperparameters Grids
 =====================================
@@ -34,7 +33,6 @@ configure_logging(level="INFO")
 # Set the random seed to always have the same example
 np.random.seed(42)
 
-# %%
 ###############################################################################
 # Load the dataset
 df_fmri = load_dataset("fmri")
@@ -64,8 +62,14 @@ scores = run_cross_validation(X=X, y=y, data=df_fmri, model=creator)
 print(scores["test_score"].mean())
 
 ###############################################################################
-# TODO
-# %%
+# Now lets tune a bit this SVM. We will use a grid search to tune the
+# regularization parameter C and the kernel. We will also tune the gamma.
+# But since the gamma is only used for the rbf kernel, we will use a
+# different grid for the rbf kernel.
+#
+# To specify two different sets of parameters for the same step, we can
+# explicitly specify the name of the step. This is done by passing the
+# ``name`` parameter to the ``add`` method.
 creator = PipelineCreator(problem_type="classification")
 creator.add("zscore")
 creator.add("svm", kernel="linear", C=[0.01, 0.1], name="svm")
@@ -92,7 +96,6 @@ scores, estimator = run_cross_validation(
 )
 
 print(scores["test_score"].mean())
-# %%
 ###############################################################################
 # It seems that we might have found a better model, but which one is it?
 print(estimator.best_params_)

--- a/examples/03_complex_models/run_hyperparameter_multiple_grids.py
+++ b/examples/03_complex_models/run_hyperparameter_multiple_grids.py
@@ -1,0 +1,99 @@
+# %%
+"""
+Tuning Multiple Hyperparameters Grids
+=====================================
+
+This example uses the 'fmri' dataset, performs simple binary classification
+using a Support Vector Machine classifier while tuning multiple hyperparameters
+grids at the same time.
+
+
+References
+----------
+Waskom, M.L., Frank, M.C., Wagner, A.D. (2016). Adaptive engagement of
+cognitive control in context-dependent decision-making. Cerebral Cortex.
+
+
+.. include:: ../../links.inc
+"""
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
+#
+# License: AGPL
+import numpy as np
+from seaborn import load_dataset
+
+from julearn import run_cross_validation
+from julearn.utils import configure_logging
+from julearn.pipeline import PipelineCreator
+
+###############################################################################
+# Set the logging level to info to see extra information
+configure_logging(level="INFO")
+
+###############################################################################
+# Set the random seed to always have the same example
+np.random.seed(42)
+
+# %%
+###############################################################################
+# Load the dataset
+df_fmri = load_dataset("fmri")
+print(df_fmri.head())
+
+###############################################################################
+# Set the dataframe in the right format
+df_fmri = df_fmri.pivot(
+    index=["subject", "timepoint", "event"], columns="region", values="signal"
+)
+
+df_fmri = df_fmri.reset_index()
+print(df_fmri.head())
+
+X = ["frontal", "parietal"]
+y = "event"
+
+###############################################################################
+# Lets do a first attempt and use a linear SVM with the default parameters.
+
+creator = PipelineCreator(problem_type="classification")
+creator.add("zscore")
+creator.add("svm", kernel="linear")
+
+scores = run_cross_validation(X=X, y=y, data=df_fmri, model=creator)
+
+print(scores["test_score"].mean())
+
+###############################################################################
+# TODO
+# %%
+creator = PipelineCreator(problem_type="classification")
+creator.add("zscore")
+creator.add("svm", kernel="linear", C=[0.01, 0.1], name="svm")
+creator.add(
+    "svm",
+    kernel="rbf",
+    C=[0.01, 0.1],
+    gamma=["scale", "auto", 1e-2, 1e-3],
+    name="svm",
+)
+
+search_params = {
+    "kind": "grid",
+    "cv": 2,  # to speed up the example
+}
+
+scores, estimator = run_cross_validation(
+    X=X,
+    y=y,
+    data=df_fmri,
+    model=creator,
+    search_params=search_params,
+    return_estimator="final",
+)
+
+print(scores["test_score"].mean())
+# %%
+###############################################################################
+# It seems that we might have found a better model, but which one is it?
+print(estimator.best_params_)
+print(estimator.best_estimator_["svm"]._gamma)

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -228,8 +228,8 @@ def run_cross_validation(
 
         if len(model_params) > 0:
             raise_error(
-                "If model is a PipelineCreator (or list of), model_params must "
-                f"be None. Currently, it contains {model_params.keys()}"
+                "If model is a PipelineCreator (or list of), model_params must"
+                f" be None. Currently, it contains {model_params.keys()}"
             )
         if isinstance(model, list):
             if any(not isinstance(m, PipelineCreator) for m in model):

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -25,7 +25,7 @@ from .inspect import Inspector
 def run_cross_validation(
     X: List[str],
     y: str,
-    model: Union[str, PipelineCreator, BaseEstimator],
+    model: Union[str, PipelineCreator, BaseEstimator, List[PipelineCreator]],
     X_types: Optional[Dict] = None,
     data: Optional[pd.DataFrame] = None,
     problem_type: Optional[str] = None,
@@ -251,8 +251,8 @@ def run_cross_validation(
             expanded_models.extend(m.split())
 
         all_pipelines = [
-            x.to_pipeline(X_types=X_types, search_params=search_params)
-            for x in expanded_models
+            model.to_pipeline(X_types=X_types, search_params=search_params)
+            for model in expanded_models
         ]
 
         if len(all_pipelines) > 1:

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -15,6 +15,7 @@ from sklearn.model_selection._search import BaseSearchCV
 from sklearn.pipeline import Pipeline
 
 from .pipeline import PipelineCreator
+from .pipeline.merger import merge_pipelines
 from .prepare import check_consistency, prepare_input_data
 from .scoring import check_scoring
 from .utils import logger, raise_error, _compute_cvmdsum
@@ -216,24 +217,52 @@ def run_cross_validation(
             "model, use PipelineCreator instead"
         )
 
-    if isinstance(model, PipelineCreator):
+    if isinstance(model, (PipelineCreator, list)):
         if preprocess is not None:
             raise_error(
-                "If model is a PipelineCreator, preprocess should be None"
+                "If model is a PipelineCreator (or list of), "
+                "preprocess should be None"
             )
         if problem_type is not None:
             raise_error("Problem type should be set in the PipelineCreator")
 
         if len(model_params) > 0:
             raise_error(
-                "If model is a PipelineCreator, model_params must be None. "
-                f"Currently, it contains {model_params.keys()}"
+                "If model is a PipelineCreator (or list of), model_params must "
+                f"be None. Currently, it contains {model_params.keys()}"
+            )
+        if isinstance(model, list):
+            if any(not isinstance(m, PipelineCreator) for m in model):
+                raise_error(
+                    "If model is a list, all elements must be PipelineCreator"
+                )
+        else:
+            model = [model]
+
+        problem_types = set([m.problem_type for m in model])
+        if len(problem_types) > 1:
+            raise_error(
+                "If model is a list of PipelineCreator, all elements must have"
+                " the same problem_type"
             )
 
-        pipeline = model.to_pipeline(
-            X_types=X_types, search_params=search_params
-        )
-        problem_type = model.problem_type
+        expanded_models = []
+        for m in model:
+            expanded_models.extend(m.split())
+
+        all_pipelines = [
+            x.to_pipeline(X_types=X_types, search_params=search_params)
+            for x in expanded_models
+        ]
+
+        if len(all_pipelines) > 1:
+            pipeline = merge_pipelines(
+                *all_pipelines, search_params=search_params
+            )
+        else:
+            pipeline = all_pipelines[0]
+
+        problem_type = model[0].problem_type
 
     elif not isinstance(model, (str, BaseEstimator)):
         raise_error(

--- a/julearn/pipeline/merger.py
+++ b/julearn/pipeline/merger.py
@@ -1,3 +1,8 @@
+"""Module to merge multiple pipelines into a single one."""
+
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>prepa
+# License: AGPL
+
 from typing import Dict
 
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV

--- a/julearn/pipeline/merger.py
+++ b/julearn/pipeline/merger.py
@@ -1,0 +1,116 @@
+from typing import Dict
+
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+from sklearn.pipeline import Pipeline
+
+from ..utils.logging import raise_error
+from ..utils.typing import EstimatorLike
+from .pipeline_creator import _prepare_hyperparameter_tuning
+from ..prepare import prepare_search_params
+
+
+def merge_pipelines(
+    *pipelines: EstimatorLike, search_params: Dict
+) -> Pipeline:
+    """Merge multiple pipelines into a single one.
+
+    Parameters
+    ----------
+    pipelines : List[EstimatorLike]
+        List of estimators that will be merged.
+    search_params : Dict
+        Dictionary with the search parameters.
+
+    Returns
+    -------
+    merged : BaseSearchCV
+        The merged pipeline as a searcher.
+    """
+
+    # Check that we only merge pipelines and searchers. And if there is a
+    # searcher, they are all of the same kind and match the search params.
+
+    search_params = prepare_search_params(search_params)
+
+    for p in pipelines:
+        if not isinstance(p, (Pipeline, GridSearchCV, RandomizedSearchCV)):
+            raise_error(
+                "Only pipelines and searchers are supported. "
+                f"Found {type(p)} instead.")
+        if isinstance(p, GridSearchCV):
+            if search_params["kind"] != "grid":
+                raise_error(
+                    "At least one of the pipelines to merge is a "
+                    "GridSearchCV, but the search params do not specify a "
+                    "grid search. These pipelines cannot be merged."
+                )
+        elif isinstance(p, RandomizedSearchCV):
+            if search_params["kind"] != "random":
+                raise_error(
+                    "At least one of the pipelines to merge is a "
+                    "RandomizedSearchCV, but the search params do not specify "
+                    "a random search. These pipelines cannot be merged."
+                )
+
+    # Check that all estimators have the same named steps in their pipelines.
+    reference_pipeline = pipelines[0]
+    if isinstance(reference_pipeline, (GridSearchCV, RandomizedSearchCV)):
+        reference_pipeline = reference_pipeline.estimator
+
+    step_names = reference_pipeline.named_steps.keys()
+
+    for p in pipelines:
+        if isinstance(p, (GridSearchCV, RandomizedSearchCV)):
+            p = p.estimator
+            if not isinstance(p, Pipeline):
+                raise_error("All searchers must use a pipeline.")
+        if step_names != p.named_steps.keys():
+            raise_error("All pipelines must have the same named steps.")
+
+    # The idea behind the merge is to create a list of parameter
+    # grids/distributions from a list of pipeline and searchers, to then
+    # wrap them into a single searcher. Since all the searchers have the same
+    # steps, this is possible. We just need to concatenate the
+    # grids/distributions from all searchers. If one of the pipelines is not
+    # a searcher, then this means that it has no hyperparameters to tune, but
+    # the pipeline is one of the hyperparameter options.
+
+    different_steps = []
+    for t_name in step_names:
+        # Get the transformer/model of the first element
+        t = reference_pipeline.named_steps[t_name]
+
+        # Check that all searchers have the same transformer/model.
+        # TODO: Fix this comparison, as it always returns False.
+        for s in pipelines[1:]:
+            if isinstance(s, (GridSearchCV, RandomizedSearchCV)):
+                if s.estimator.named_steps[t_name] != t:
+                    different_steps.append(t_name)
+                    break
+            else:
+                if s.named_steps[t_name] != t:
+                    different_steps.append(t_name)
+                    break
+
+    # Then, we will update the grid of the searchers that have different
+    # transformer/model.
+    all_grids = []
+    for s in pipelines:
+        if isinstance(s, GridSearchCV):
+            t_grid = s.param_grid.copy()
+        elif isinstance(s, RandomizedSearchCV):
+            t_grid = s.param_distributions.copy()
+        else:
+            t_grid = {}
+        for t_name in different_steps:
+            if isinstance(s, (GridSearchCV, RandomizedSearchCV)):
+                t_grid[t_name] = [s.estimator.named_steps[t_name]]
+            else:
+                t_grid[t_name] = [s.named_steps[t_name]]
+        all_grids.append(t_grid)
+
+    # Finally, we will concatenate the grids and create a new searcher.
+    new_searcher = _prepare_hyperparameter_tuning(
+        all_grids, search_params, reference_pipeline
+    )
+    return new_searcher

--- a/julearn/pipeline/merger.py
+++ b/julearn/pipeline/merger.py
@@ -76,20 +76,20 @@ def merge_pipelines(
     # the pipeline is one of the hyperparameter options.
 
     different_steps = []
-    for t_name in step_names:
+    for t_step_name in step_names:
         # Get the transformer/model of the first element
-        t = reference_pipeline.named_steps[t_name]
+        t = reference_pipeline.named_steps[t_step_name]
 
         # Check that all searchers have the same transformer/model.
         # TODO: Fix this comparison, as it always returns False.
         for s in pipelines[1:]:
             if isinstance(s, (GridSearchCV, RandomizedSearchCV)):
-                if s.estimator.named_steps[t_name] != t:
-                    different_steps.append(t_name)
+                if s.estimator.named_steps[t_step_name] != t:
+                    different_steps.append(t_step_name)
                     break
             else:
-                if s.named_steps[t_name] != t:
-                    different_steps.append(t_name)
+                if s.named_steps[t_step_name] != t:
+                    different_steps.append(t_step_name)
                     break
 
     # Then, we will update the grid of the searchers that have different

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -309,10 +309,9 @@ class PipelineCreator:
         """Whether the PipelineCreator has a model."""
         return self._added_model
 
-
     def copy(self) -> "PipelineCreator":
         """Create a copy of the PipelineCreator.
-        
+
         Returns
         -------
         PipelineCreator
@@ -544,8 +543,6 @@ class PipelineCreator:
         )
         logger.debug("Pipeline created")
         return out
-
-
 
     @staticmethod
     def _wrap_target_model(

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -216,7 +216,7 @@ class PipelineCreator:
 
         # Check that if the name is already in the steps, we are adding them
         # at the same place.
-        if name is not None and name in [x.name for x in self._steps]:
+        if name is not None and name in [step.name for step in self._steps]:
             if self._steps[-1].name != name:
                 raise_error(
                     "Repeated step names are only allowed to be added "

--- a/julearn/pipeline/test/test_merger.py
+++ b/julearn/pipeline/test/test_merger.py
@@ -1,10 +1,17 @@
+"""Test the pipeline merger module."""
+
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>prepa
+# License: AGPL
+
+import pytest
+from sklearn.svm import SVC
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.pipeline import Pipeline
 from julearn.pipeline import PipelineCreator
 from julearn.pipeline.merger import merge_pipelines
 
 
-def test_merger_pipelines():
+def test_merger_pipelines() -> None:
     """Test the pipeline merger."""
 
     creator1 = PipelineCreator(problem_type="classification")
@@ -34,9 +41,7 @@ def test_merger_pipelines():
     creator3.add("rf", max_features=[2, 3, 7, 42])
     pipe3 = creator3.to_pipeline(search_params=search_params)
 
-    merged = merge_pipelines(
-        pipe1, pipe2, pipe3, search_params=search_params
-    )
+    merged = merge_pipelines(pipe1, pipe2, pipe3, search_params=search_params)
 
     assert isinstance(merged, RandomizedSearchCV)
     assert isinstance(merged.estimator, Pipeline)
@@ -46,3 +51,55 @@ def test_merger_pipelines():
     assert "rf" == named_steps[2]
     assert len(merged.param_distributions) == 3
     assert merged.param_distributions[-1]["rf__max_features"] == [2, 3, 7, 42]
+
+
+def test_merger_errors() -> None:
+    """Test that the merger raises errors when it should."""
+    creator1 = PipelineCreator(problem_type="classification")
+    creator1.add("zscore", name="scaler", apply_to="continuous")
+    creator1.add("rf")
+
+    creator2 = PipelineCreator(problem_type="classification")
+    creator2.add("scaler_robust", name="scaler", apply_to="continuous")
+    creator2.add("rf", n_estimators=[10, 100])
+
+    pipe1 = creator1.to_pipeline()
+    pipe2 = creator2.to_pipeline(search_params={"kind": "grid"})
+
+    with pytest.raises(ValueError, match="Only pipelines and searchers"):
+        merge_pipelines(pipe1, SVC(), search_params=None)
+
+    search_params = {"kind": "random"}
+
+    with pytest.raises(
+        ValueError,
+        match="At least one of the pipelines to merge is a GridSearchCV",
+    ):
+        merge_pipelines(pipe1, pipe2, search_params=search_params)
+
+    search_params = {"kind": "grid"}
+    pipe2 = creator2.to_pipeline(search_params={"kind": "random"})
+
+    with pytest.raises(
+        ValueError,
+        match="one of the pipelines to merge is a RandomizedSearchCV",
+    ):
+        merge_pipelines(pipe1, pipe2, search_params=search_params)
+
+    pipe3 = GridSearchCV(SVC(), param_grid={"C": [1, 10]})
+    with pytest.raises(
+        ValueError,
+        match="All searchers must use a pipeline.",
+    ):
+        merge_pipelines(pipe1, pipe3, search_params=None)
+
+    creator4 = PipelineCreator(problem_type="classification")
+    creator4.add("scaler_robust", name="scaler", apply_to="continuous")
+    creator4.add("pca")
+    creator4.add("rf", n_estimators=[10, 100])
+    pipe4 = creator4.to_pipeline(search_params={"kind": "grid"})
+    with pytest.raises(
+        ValueError,
+        match="must have the same named steps.",
+    ):
+        merge_pipelines(pipe1, pipe4, search_params=None)

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -352,16 +352,15 @@ def test_added_repeated_transformers() -> None:
     assert pipeline_creator._steps[0].name == "zscore"
     assert pipeline_creator._steps[1].name == "zscore_1"
 
-
-def test_hyperparameter_ter():
-    (
-        PipelineCreator(problem_type="classification").add(
-            "confound_removal", model_confound=RandomForestRegressor()
-        )
-    )
+# TODO: Identify what are we testing here
+# def test_hyperparameter_ter() -> None:
+#     PipelineCreator(problem_type="classification").add(
+#         "confound_removal", model_confound=RandomForestRegressor()
+#     )
 
 
-def test_target_pipe(X_iris, y_iris):
+def test_target_pipe(X_iris, y_iris) -> None:
+    """Test that the target pipeline works correctly."""
     X_types = {
         "continuous": ["sepal_length", "sepal_width", "petal_length"],
         "confounds": ["petal_width"],
@@ -380,31 +379,33 @@ def test_target_pipe(X_iris, y_iris):
     pipe.fit(X_iris, y_iris)
 
 
-def test_raise_wrong_problem_type():
+def test_raise_wrong_problem_type() -> None:
+    """Test that the correct error is raised when the problem type is wrong."""
     with pytest.raises(ValueError, match="`problem_type` should"):
         PipelineCreator(problem_type="binary")
 
 
-def test_raise_wrong_problem_type_added_to_step():
+def test_raise_wrong_problem_type_added_to_step() -> None:
+    """Test error when problem type is passed to a step."""
     with pytest.raises(ValueError, match="Please provide the problem_type"):
         PipelineCreator(problem_type="classification").add(
             "svm", problem_type="classification"
         )
 
 
-def test_raise_error_not_target_pipe():
+def test_raise_error_not_target_pipe() -> None:
+    """Test error when target pipeline is not applied to target."""
     with pytest.raises(ValueError, match="TargetPipelineCreator can"):
         target_pipeline = TargetPipelineCreator().add(
             "confound_removal", confounds=["confounds", "continuous"]
         )
-        (
-            PipelineCreator(problem_type="regression").add(
-                target_pipeline, apply_to="confounds"
-            )
+        PipelineCreator(problem_type="regression").add(
+            target_pipeline, apply_to="confounds"
         )
 
 
-def test_raise_pipe_no_model():
+def test_raise_pipe_no_model() -> None:
+    """Test error when no model is added to the pipeline."""
     X_types = {
         "continuous": [
             "sepal_length",
@@ -418,7 +419,8 @@ def test_raise_pipe_no_model():
         pipeline_creator.to_pipeline(X_types)
 
 
-def test_raise_pipe_wrong_searcher():
+def test_raise_pipe_wrong_searcher() -> None:
+    """Test error when the searcher is not a valid julearn searcher."""
     X_types = {
         "continuous": [
             "sepal_length",
@@ -439,7 +441,7 @@ def test_raise_pipe_wrong_searcher():
         )
 
 
-def test_PipelineCreator_repeated_steps():
+def test_PipelineCreator_repeated_steps() -> None:
     """Test the pipeline creator with repeated steps."""
 
     # Without explicit naming, it should not be considered repeated
@@ -461,7 +463,18 @@ def test_PipelineCreator_repeated_steps():
     assert creator2._steps[1].name == "scale"
 
 
-def test_PipelineCreator_split():
+def test_PipelineCreator_repeated_steps_error() -> None:
+    """Test error with repeated steps."""
+
+    # With explicit naming, it should be considered repeated
+    creator = PipelineCreator(problem_type="classification")
+    creator.add("zscore", name="scale", apply_to="continuous")
+    creator.add("pca", name="pca", apply_to="continuous")
+    with pytest.raises(ValueError, match="Repeated step names are only"):
+        creator.add("scaler_robust", name="scale", apply_to="continuous")
+
+
+def test_PipelineCreator_split() -> None:
     """Test the pipeline creator split."""
     # No repetition, split should create one pipeline
     creator1 = PipelineCreator(problem_type="classification")

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -12,7 +12,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.preprocessing import RobustScaler, StandardScaler
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.svm import SVC
 
 from julearn.base import ColumnTypesLike, WrapModel
@@ -351,6 +351,7 @@ def test_added_repeated_transformers() -> None:
     assert len(pipeline_creator._steps) == 3
     assert pipeline_creator._steps[0].name == "zscore"
     assert pipeline_creator._steps[1].name == "zscore_1"
+
 
 # TODO: Identify what are we testing here
 # def test_hyperparameter_ter() -> None:

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -354,9 +354,11 @@ def test_added_repeated_transformers() -> None:
 
 
 def test_hyperparameter_ter():
-    (PipelineCreator(problem_type="classification")
-     .add("confound_removal", model_confound=RandomForestRegressor())
-     )
+    (
+        PipelineCreator(problem_type="classification").add(
+            "confound_removal", model_confound=RandomForestRegressor()
+        )
+    )
 
 
 def test_target_pipe(X_iris, y_iris):
@@ -364,15 +366,17 @@ def test_target_pipe(X_iris, y_iris):
         "continuous": ["sepal_length", "sepal_width", "petal_length"],
         "confounds": ["petal_width"],
     }
-    target_pipeline = (TargetPipelineCreator()
-                       .add("confound_removal",
-                            confounds=["confounds", "continuous"]))
-    pipeline_creator = (PipelineCreator(problem_type='regression')
-                        .add(target_pipeline, apply_to="target")
-                        .add("svm", C=[1, 2])
-                        )
+    target_pipeline = TargetPipelineCreator().add(
+        "confound_removal", confounds=["confounds", "continuous"]
+    )
+    pipeline_creator = (
+        PipelineCreator(problem_type="regression")
+        .add(target_pipeline, apply_to="target")
+        .add("svm", C=[1, 2])
+    )
     pipe = pipeline_creator.to_pipeline(
-        X_types, search_params=dict(kind="random"))
+        X_types, search_params=dict(kind="random")
+    )
     pipe.fit(X_iris, y_iris)
 
 
@@ -384,44 +388,55 @@ def test_raise_wrong_problem_type():
 def test_raise_wrong_problem_type_added_to_step():
     with pytest.raises(ValueError, match="Please provide the problem_type"):
         PipelineCreator(problem_type="classification").add(
-            "svm", problem_type="classification")
+            "svm", problem_type="classification"
+        )
 
 
 def test_raise_error_not_target_pipe():
     with pytest.raises(ValueError, match="TargetPipelineCreator can"):
-        target_pipeline = (TargetPipelineCreator()
-                           .add("confound_removal",
-                                confounds=["confounds", "continuous"]))
-        (PipelineCreator(problem_type='regression')
-         .add(target_pipeline, apply_to="confounds")
-         )
+        target_pipeline = TargetPipelineCreator().add(
+            "confound_removal", confounds=["confounds", "continuous"]
+        )
+        (
+            PipelineCreator(problem_type="regression").add(
+                target_pipeline, apply_to="confounds"
+            )
+        )
 
 
 def test_raise_pipe_no_model():
     X_types = {
-        "continuous": ["sepal_length", "sepal_width",
-                       "petal_length", "petal_width"],
+        "continuous": [
+            "sepal_length",
+            "sepal_width",
+            "petal_length",
+            "petal_width",
+        ],
     }
-    pipeline_creator = (PipelineCreator(problem_type='regression')
-                        .add("zscore")
-                        )
+    pipeline_creator = PipelineCreator(problem_type="regression").add("zscore")
     with pytest.raises(ValueError, match="Cannot create a pipe"):
         pipeline_creator.to_pipeline(X_types)
 
 
 def test_raise_pipe_wrong_searcher():
     X_types = {
-        "continuous": ["sepal_length", "sepal_width",
-                       "petal_length", "petal_width"],
+        "continuous": [
+            "sepal_length",
+            "sepal_width",
+            "petal_length",
+            "petal_width",
+        ],
     }
-    pipeline_creator = (PipelineCreator(problem_type='regression')
-                        .add("svm", C=[1, 2])
-                        )
+    pipeline_creator = PipelineCreator(problem_type="regression").add(
+        "svm", C=[1, 2]
+    )
     with pytest.raises(
-            ValueError,
-            match="The searcher no_search is not a valid julearn searcher"):
+        ValueError,
+        match="The searcher no_search is not a valid julearn searcher",
+    ):
         pipeline_creator.to_pipeline(
-            X_types, search_params=dict(kind="no_search"))
+            X_types, search_params=dict(kind="no_search")
+        )
 
 
 def test_PipelineCreator_repeated_steps():
@@ -435,7 +450,6 @@ def test_PipelineCreator_repeated_steps():
     assert len(creator._steps) == 3
     assert creator._steps[0].name == "zscore"
     assert creator._steps[1].name == "zscore_1"
-
 
     # With explicit naming, it should be considered repeated
     creator2 = PipelineCreator(problem_type="classification")
@@ -508,7 +522,7 @@ def test_PipelineCreator_split():
     assert out3[2]._steps[0].name == "scale"
     assert out3[2]._steps[1].name == "rf"
 
-    #Repeated two step twice, split should create 4 pipelines
+    # Repeated two step twice, split should create 4 pipelines
     creator4 = PipelineCreator(problem_type="classification")
     creator4.add("zscore", name="scale", apply_to="continuous")
     creator4.add("scaler_robust", name="scale", apply_to="continuous")

--- a/julearn/prepare.py
+++ b/julearn/prepare.py
@@ -6,7 +6,7 @@
 
 import re
 from collections import Counter
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -451,3 +451,32 @@ def _check_x_types(X_types: Optional[Dict], X: List[str]) -> Dict[str, List]:
             f"{undefined_columns}. They will be treated as continuous."
         )
     return X_types
+
+
+def prepare_search_params(
+    search_params: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Prepare the parameters for the search.
+
+    Parameters
+    ----------
+    search_params : dict, optional
+        The parameters for the search.
+
+    Returns
+    -------
+    search_params : dict
+        The parameters for the search, ready to use.
+    """
+
+    if search_params is None:
+        search_params = {}
+    else:
+        search_params = search_params.copy()
+
+    if "cv" not in search_params:
+        search_params["cv"] = None
+    if "kind" not in search_params:
+        search_params["kind"] = "grid"
+
+    return search_params

--- a/julearn/tests/test_api.py
+++ b/julearn/tests/test_api.py
@@ -347,21 +347,6 @@ def test_run_cv_errors(df_iris: pd.DataFrame) -> None:
             problem_type="classification",
         )
 
-    model = "svm"
-    model_params = {"svm__C": 1}
-    search_params = {"kind": "grid", "cv": 3}
-    with pytest.raises(ValueError, match="search parameters were specified"):
-        run_cross_validation(
-            X=X,
-            y=y,
-            data=df_iris,
-            X_types=X_types,
-            model=model,
-            model_params=model_params,
-            search_params=search_params,
-            problem_type="classification",
-        )
-
 
 def test_tune_hyperparam_gridsearch(df_iris: pd.DataFrame) -> None:
     """Test a run_cross_validation with hyperparameter tuning (gridsearch).

--- a/julearn/transformers/dataframe/set_column_types.py
+++ b/julearn/transformers/dataframe/set_column_types.py
@@ -32,13 +32,12 @@ class SetColumnTypes(JuTransformer):
         Not really useful for this one, but here for compatibility.
     """
 
-    def __init__(self,
-                 X_types: Optional[Dict[str, List[str]]] = None,
-                 row_select_col_type:  Optional[ColumnTypesLike] = None,
-                 row_select_vals:  Optional[Union[str,
-                                                  int, list, bool]] = None,
-
-                 ):
+    def __init__(
+        self,
+        X_types: Optional[Dict[str, List[str]]] = None,
+        row_select_col_type: Optional[ColumnTypesLike] = None,
+        row_select_vals: Optional[Union[str, int, list, bool]] = None,
+    ):
         if X_types is None:
             X_types = {}
 
@@ -51,9 +50,10 @@ class SetColumnTypes(JuTransformer):
                 )
         self.X_types = X_types
         super().__init__(
-            apply_to="*", needed_types=None,
+            apply_to="*",
+            needed_types=None,
             row_select_col_type=row_select_col_type,
-            row_select_vals=row_select_vals
+            row_select_vals=row_select_vals,
         )
 
     def _fit(


### PR DESCRIPTION
This is from a scikit-learn example:

```Python
tuned_parameters = [{'kernel': ['rbf'], 'gamma': [1e-3, 1e-4],
                     'C': [1, 10, 100, 1000]},
                    {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}]

clf = GridSearchCV(
    SVC(), tuned_parameters, scoring='%s_macro' % score
)
```

This example creates two grids, one for the `rbf` kernel, exploring `gamma`, and one for the `linear` kernel, without testing `gamma`, because it does not make sense.

In order to do this, we need to set the following `model_params`:
```Python
model_params = {
    'svm__C': [1, 10, 100, 1000],
    'svm__kernel': ['rbf', linear'],
    'svm__gamma': [1e-3, 1e-4]
}
```
However, we will be testing different `gamma` options for the `linear` kernel (useless).

We need to find a way of specifying sets of parameters to be tested.