### PR TITLE
[MAINT]: Improve `codespell` support

### DIFF
--- a/docs/api/viz.rst
+++ b/docs/api/viz.rst
@@ -1,5 +1,5 @@
 *************
-Vizualization
+Visualization
 *************
 
 .. warning::

--- a/docs/changes/contributors.inc
+++ b/docs/changes/contributors.inc
@@ -3,4 +3,4 @@
 .. _Kaustubh Patil: http://appliedml.org
 .. _Shammi More: https://www.fz-juelich.de/SharedDocs/Personen/INM/INM-7/EN/More_s.html?nn=654218
 .. _Leonard Sasse: https://github.com/LeSasse
-
+.. _Synchon Mandal: https://github.com/synchon

--- a/docs/changes/newsfragments/232.misc
+++ b/docs/changes/newsfragments/232.misc
@@ -1,0 +1,1 @@
+Improve ``codespell`` support and fix typos in documentation by `Synchon Mandal`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,15 @@ from sphinx_gallery.sorting import ExplicitOrder
 from pathlib import Path
 import sys
 
+# Check if sphinx-multiversion is installed
+use_multiversion = False
+try:
+    import sphinx_multiversion  # noqa: F401
+
+    use_multiversion = True
+except ImportError:
+    pass
+
 curdir = Path(__file__).parent
 sys.path.append((curdir / "sphinxext").as_posix())
 
@@ -43,12 +52,14 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_gallery.gen_gallery",
-    "sphinx_multiversion",
     "numpydoc",
     "gh_substitutions",
     "sphinx_copybutton",
     "bokeh.sphinxext.bokeh_plot",
 ]
+
+if use_multiversion:
+    extensions.append("sphinx_multiversion")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,10 +39,10 @@ Here you can find the comprehensive list of flags that can be set:
      - The user might think that a certain feature is considered in the model
        when it is not.
    * - ``disable_x_verbose``
-     - Disable printing the list of expaneded column names in ``X``. If set
+     - Disable printing the list of expanded column names in ``X``. If set
        to ``True``, the list of column names will not be printed.
      - The user will not see the expanded column names in ``X``.
    * - ``disable_xtypes_verbose``
-     - Disable printing the list of expaneded column names in ``X_types``. If
+     - Disable printing the list of expanded column names in ``X_types``. If
        set to ``True``, the list of types of X will not be printed.
-     - The user will not see the expaned ``X_types`` column names.
+     - The user will not see the expanded ``X_types`` column names.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -73,7 +73,7 @@ Optional Dependencies
 =====================
 
 Some functionality of Julearn requires additional packages. These are not
-insalled by default. If you want to use these features, you need to specify
+installed by default. If you want to use these features, you need to specify
 them during installation. For example, if you want to use the `:mod:.viz`
 module, you need to install the ``viz`` optional dependencies as follows:
 

--- a/docs/maintaining.rst
+++ b/docs/maintaining.rst
@@ -50,7 +50,7 @@ before proceeding.
 to generate the proper changelog that should be reflected in
 ``docs/whats_new.rst``.
 
-#. Commit the chages, make a PR and merge via a merge commit.
+#. Commit the changes, make a PR and merge via a merge commit.
 
 #. Make sure you are in sync with the main branch.
 

--- a/docs/what_really_need_know/cross_validation.rst
+++ b/docs/what_really_need_know/cross_validation.rst
@@ -16,7 +16,7 @@ Cross-validation - The fundamentals
 This means that in order to evaluate if a model is *successful* in learning,
 we need to evaluate if it is able to predict new data. Thus, we need to have
 separate data for learning and testing. At the same time, data is a valuable
-ressource in machine learning and one wants to use it as efficeint as possible.
+resource in machine learning and one wants to use it as efficeint as possible.
 
 To solve this, we use *cross validation*. The core idea is that we want to
 train (also named *fit*) a model on a subset of our data and evaluate it on a

--- a/docs/what_really_need_know/index.rst
+++ b/docs/what_really_need_know/index.rst
@@ -15,7 +15,7 @@ via its parameters.
 But why is basically everything based on one `cross_validation` function? Well,
 because doing proper cross-validation is of utmost importance in machine
 learning and it is not as easy as it might seem at first glance. If you want to
-understand why, reading the sub-chapter :ref:`cross_validation` ist a good
+understand why, reading the sub-chapter :ref:`cross_validation` is a good
 starting point.
 
 Once you are familiar with the basics of *cross-validation*, you can follow

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -72,7 +72,7 @@ Features
 ^^^^^^^^
 
 - Add user facing ``create_pipeline`` function by `Sami Hamdan`_
-- Add CV schemes for stratifying continous variables, useful for
+- Add CV schemes for stratifying continuous variables, useful for
   regression problems. Check :class:`.ContinuousStratifiedKFold` and
   :class:`.RepeatedContinuousStratifiedKFold` by
   `Fede Raimondo`_ and `Shammi More`_

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -4,3 +4,4 @@ fwe
 fpr
 master
 whis
+jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,14 @@ write_to = "julearn/_version.py"
 line-length = 79
 target-version = ["py38"]
 
+[tool.codespell]
+skip = "*/auto_examples/*,*.html,.git/,*.pyc,*/_build/*"
+count = ""
+quiet-level = 3
+ignore-words = "ignore_words.txt"
+interactive = 0
+builtin = "clear,rare,informal,names,usage,code"
+
 [tool.towncrier]
 directory = "docs/changes/newsfragments"
 filename = "docs/whats_new.rst"

--- a/tox.ini
+++ b/tox.ini
@@ -160,11 +160,3 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
 precision = 2
-
-[codespell]
-skip = docs/auto_*,*.html,.git/,*.pyc,docs/_build
-count =
-quiet-level = 3
-ignore-words = ignore_words.txt
-interactive = 0
-builtin = clear,rare,informal,names,usage

--- a/tox.ini
+++ b/tox.ini
@@ -81,8 +81,9 @@ commands =
 skip_install = true
 deps =
     codespell
+    tomli
 commands =
-    codespell --config tox.ini examples/ julearn/ scratch/ tools/
+    codespell --toml {toxinidir}/pyproject.toml {toxinidir}/docs/ {toxinidir}/examples/ {toxinidir}/julearn/ {toxinidir}/README.md
 
 ################
 # Tool configs #


### PR DESCRIPTION
`codespell` now supports reading config from `pyproject.toml`. This will allow us to keep `tox.ini` clean.