### PR TITLE
[DOC]: Not working links in documentation

### DIFF
--- a/docs/changes/newsfragments/168.doc
+++ b/docs/changes/newsfragments/168.doc
@@ -1,0 +1,1 @@
+Fix cross-referencing links in documentation by `Synchon Mandal`_

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -49,10 +49,10 @@ def run_cross_validation(
     ----------
     X : str, list(str) or numpy.array
         The features to use.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     y : str or numpy.array
         The targets to predict.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     model : str or scikit-learn compatible model.
         If string, it will use one of the available models.
     X_types : dict[str, list of str]
@@ -60,7 +60,7 @@ def run_cross_validation(
         columns of this column type as a list of str.
     data : pandas.DataFrame | None
         DataFrame with the data (optional).
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     problem_type : str
         The kind of problem to model.
 
@@ -108,7 +108,7 @@ def run_cross_validation(
 
     groups : str or numpy.array | None
         The grouping labels in case a Group CV is used.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     scoring : ScorerLike, optional
         The scoring metric to use.
         See https://scikit-learn.org/stable/modules/model_evaluation.html for
@@ -141,7 +141,7 @@ def run_cross_validation(
         * 'scoring': If a searcher is going to be used, the scoring metric to
             evaluate the performance.
 
-        See https://juaml.github.io/julearn/hyperparameters.html for details.
+        See :ref:`hp_tuning` for details.
     seed : int | None
         If not None, set the random seed before any operation. Useful for
         reproducibility.

--- a/julearn/prepare.py
+++ b/julearn/prepare.py
@@ -38,15 +38,15 @@ def _validate_input_data_df(
     ----------
     X : str, list(str)
         The features to use.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     y : str
         The targets to predict.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     df : pandas.DataFrame with the data.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     groups : str | None
         The grouping labels in case a Group CV is used.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
 
     Raises
     ------
@@ -78,15 +78,15 @@ def _validate_input_data_df_ext(
     ----------
     X : str, list(str)
         The features to use.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     y : str
         The targets to predict.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     df : pandas.DataFrame with the data.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     groups : str | None
         The grouping labels in case a Group CV is used.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
 
     Raises
     ------
@@ -217,18 +217,18 @@ def prepare_input_data(
     ----------
     X : str, list(str)
         The features to use.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     y : str
         The targets to predict.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     df : pandas.DataFrame with the data.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     pos_labels : str, int, float or list | None
         The labels to interpret as positive. If not None, every element from y
         will be converted to 1 if is equal or in pos_labels and to 0 if not.
     groups : str | None
         The grouping labels in case a Group CV is used.
-        See https://juaml.github.io/julearn/input.html for details.
+        See :ref:`data_usage` for details.
     X_types : dict | None
         A dictionary containing keys with column type as a str and the
         columns of this column type as a list of str.


### PR DESCRIPTION
Different links in the documentation are not working. 
For example under julearn.api.run_cross_validation (https://juaml.github.io/julearn/v0.2.3/api.html) this link (https://juaml.github.io/julearn/input.html) appears multiple times but leads to a 404.
