### PR TITLE
Fix/target_transform_score_log

### DIFF
--- a/julearn/api.py
+++ b/julearn/api.py
@@ -252,7 +252,7 @@ def run_cross_validation(  # noqa: C901
         for m in model:
             expanded_models.extend(m.split())
 
-        wrap_score = expanded_models[-1]._added_target_transformer
+        has_target_transformer = expanded_models[-1]._added_target_transformer
         all_pipelines = [
             model.to_pipeline(X_types=X_types, search_params=search_params)
             for model in expanded_models
@@ -265,6 +265,8 @@ def run_cross_validation(  # noqa: C901
         else:
             pipeline = all_pipelines[0]
 
+        if has_target_transformer and not pipeline[-1].can_inverse_transform():
+            wrap_score = True
         problem_type = model[0].problem_type
 
     elif not isinstance(model, (str, BaseEstimator)):
@@ -322,10 +324,13 @@ def run_cross_validation(  # noqa: C901
             raise_error(
                 "The following model_params are incorrect: " f"{unused_params}"
             )
-        wrap_score = pipeline_creator._added_target_transformer
+        has_target_transformer = pipeline_creator._added_target_transformer
         pipeline = pipeline_creator.to_pipeline(
             X_types=X_types, search_params=search_params
         )
+
+        if has_target_transformer and not pipeline[-1].can_inverse_transform():
+            wrap_score = True
 
     # Log some information
     logger.info("= Data Information =")

--- a/julearn/transformers/target/ju_transformed_target_model.py
+++ b/julearn/transformers/target/ju_transformed_target_model.py
@@ -213,6 +213,17 @@ class JuTransformedTargetModel(JuBaseEstimator):
         """
         return self.transformer.transform(X, y)
 
+    def can_inverse_transform(self) -> bool:
+        """Check if the target can be inverse transformed.
+
+        Returns
+        -------
+        bool
+            True if the target can be inverse transformed, False otherwise.
+
+        """
+        return self.transformer.can_inverse_transform()
+
     @property
     def classes_(self) -> np.ndarray:
         """Get the classes of the model."""

--- a/julearn/utils/logging.py
+++ b/julearn/utils/logging.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 from pathlib import Path
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Dict, NoReturn, Optional, Type, Union
-from warnings import warn
+import warnings
 
 
 logger = logging.getLogger("julearn")
@@ -155,7 +155,7 @@ def configure_logging(
         if not isinstance(fname, Path):
             fname = Path(fname)
         if fname.exists() and overwrite is None:
-            warn(
+            warnings.warn(
                 f"File ({fname.absolute()!s}) exists. "
                 "Messages will be appended. Use overwrite=True to "
                 "overwrite or overwrite=False to avoid this message.",
@@ -235,8 +235,15 @@ def warn_with_log(
         The warning subclass (default RuntimeWarning).
 
     """
-    logger.warning(msg)
-    warn(msg, category=category, stacklevel=2)
+
+    # This is somehow nasty. If there is a filter active, then the warning
+    # will still be logged. So we need to check if any of the filters
+    # will ignore this warning. If this is the case, then do not log it.
+    this_filters = [x for x in warnings.filters if issubclass(x[2], category)]
+    skip_log = len(this_filters) > 0 and this_filters[0][0] == "ignore"
+    if not skip_log:
+        logger.warning(msg)
+    warnings.warn(msg, category=category, stacklevel=2)
 
 
 class WrapStdOut(logging.StreamHandler):


### PR DESCRIPTION
Fix for #236

a) Do not log warnings that will be filtered.
b) Do not wrap the scorer if the target transformer can inverse transform.