### PR TITLE
[BUG]: Hyperparameters are not set if an estimator is used instead of a string in PipelineCreator

### DIFF
--- a/docs/changes/newsfragments/247.bugfix
+++ b/docs/changes/newsfragments/247.bugfix
@@ -1,0 +1,1 @@
+Fix hyperparameter not being set in `PipelineCreator.add` when an object is used as model, by `Fede Raimondo`_

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -256,6 +256,8 @@ class PipelineCreator:
             step = self._get_estimator_from(
                 step, self.problem_type, **params_to_set
             )
+        elif len(params_to_set) > 0:
+            step.set_params(**params_to_set)
 
         # JuEstimators accept the apply_to parameter and return needed types
         if isinstance(step, JuEstimatorLike):

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -14,6 +14,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.preprocessing import RobustScaler, StandardScaler
 from sklearn.svm import SVC
+from sklearn.dummy import DummyClassifier
 
 from julearn.base import ColumnTypesLike, WrapModel
 from julearn.models import get_model
@@ -578,3 +579,33 @@ def test_PipelineCreator_split() -> None:
 
     assert isinstance(out4[3]._steps[0].estimator, RobustScaler)
     assert isinstance(out4[3]._steps[2].estimator, SVC)
+
+
+def test_PipelineCreator_set_hyperparameter() -> None:
+    """Test the pipeline creator hyperparameter set through the add method."""
+
+    creator_default = PipelineCreator(problem_type="classification", apply_to="*")
+    creator_default.add("dummy")
+    model_default = creator_default.to_pipeline()
+    assert model_default.steps[-1][1].get_params()["strategy"] != "uniform"
+
+    creator1 = PipelineCreator(problem_type="classification", apply_to="*")
+    creator1.add("dummy", strategy="uniform", name="dummy")
+
+    model1 = creator1.to_pipeline()
+
+    assert model1.steps[-1][1].get_params()["strategy"] == "uniform"
+
+    creator2 = PipelineCreator(problem_type="classification", apply_to="*")
+    creator2.add(DummyClassifier(strategy="uniform"), name="dummy")
+
+    model2 = creator2.to_pipeline()
+
+    assert model2.steps[-1][1].get_params()["strategy"] == "uniform"
+
+    creator3 = PipelineCreator(problem_type="classification", apply_to="*")
+    creator3.add(DummyClassifier(), strategy="uniform", name="dummy")
+
+    model3 = creator3.to_pipeline()
+
+    assert model3.steps[-1][1].get_params()["strategy"] == "uniform"

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -10,11 +10,11 @@ from typing import Callable, Dict, List
 import pandas as pd
 import pytest
 from pytest_lazyfixture import lazy_fixture
+from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.preprocessing import RobustScaler, StandardScaler
 from sklearn.svm import SVC
-from sklearn.dummy import DummyClassifier
 
 from julearn.base import ColumnTypesLike, WrapModel
 from julearn.models import get_model
@@ -584,7 +584,9 @@ def test_PipelineCreator_split() -> None:
 def test_PipelineCreator_set_hyperparameter() -> None:
     """Test the pipeline creator hyperparameter set through the add method."""
 
-    creator_default = PipelineCreator(problem_type="classification", apply_to="*")
+    creator_default = PipelineCreator(
+        problem_type="classification", apply_to="*"
+    )
     creator_default.add("dummy")
     model_default = creator_default.to_pipeline()
     assert model_default.steps[-1][1].get_params()["strategy"] != "uniform"


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

If I set a hyperparameter as part of the `PipelineCreator.add` method, without providing several options so there's no tuning involved, the hyperparameter is not set. This only happens when the estimator is not a string but an already instantiated scikit-learn compatible object.

```python
creator = PipelineCreator(problem_type="classification", apply_to="*")
creator.add(DummyClassifier(), strategy="constant", name="dummy")
```

If I then do convert this to a pipeline and check the model:
```python
model = creator.to_pipeline()
print(model.steps[-1][1].get_params())
```

I get this:

```
{'apply_to': ColumnTypes<types={'*'}; pattern=.*>, 'model': DummyClassifier(), 'needed_types': None, 'constant': None, 'random_state': None, 'strategy': 'prior'}
```

that means that the `strategy` was not set.


### Expected Behavior

I would expect the parameters to be set.

### Steps To Reproduce

1. Install julearn
2. Run:

```Python
from julearn.pipeline import PipelineCreator
from sklearn.dummy import DummyClassifier

creator = PipelineCreator(problem_type="classification", apply_to="*")
creator.add(DummyClassifier(), strategy="uniform", name="dummy")

model = creator.to_pipeline()

print(model.steps[-1][1].get_params())
```


### Environment

```markdown
alabaster @ file:///home/conda/feedstock_root/build_artifacts/alabaster_1673645646525/work
annotated-types @ file:///home/conda/feedstock_root/build_artifacts/annotated-types_1696634205638/work
anyio @ file:///home/conda/feedstock_root/build_artifacts/anyio_1700835416766/work
appdirs==1.4.4
appnope @ file:///home/conda/feedstock_root/build_artifacts/appnope_1649077682618/work
argon2-cffi @ file:///home/conda/feedstock_root/build_artifacts/argon2-cffi_1692818318753/work
argon2-cffi-bindings @ file:///Users/runner/miniforge3/conda-bld/argon2-cffi-bindings_1695386618041/work
arrow @ file:///home/conda/feedstock_root/build_artifacts/arrow_1696128962909/work
asttokens @ file:///home/conda/feedstock_root/build_artifacts/asttokens_1698341106958/work
async-generator==1.10
attrs @ file:///home/conda/feedstock_root/build_artifacts/attrs_1683424013410/work
Babel @ file:///home/conda/feedstock_root/build_artifacts/babel_1698174530262/work
backcall @ file:///home/conda/feedstock_root/build_artifacts/backcall_1592338393461/work
backports.functools-lru-cache @ file:///home/conda/feedstock_root/build_artifacts/backports.functools_lru_cache_1687772187254/work
beautifulsoup4 @ file:///home/conda/feedstock_root/build_artifacts/beautifulsoup4_1680888073205/work
black @ file:///Users/runner/miniforge3/conda-bld/black-recipe_1698342764269/work
bleach @ file:///home/conda/feedstock_root/build_artifacts/bleach_1696630167146/work
bokeh @ file:///home/conda/feedstock_root/build_artifacts/bokeh_1699566645499/work
Brotli @ file:///Users/runner/miniforge3/conda-bld/brotli-split_1695989934239/work
brotlipy @ file:///Users/runner/miniforge3/conda-bld/brotlipy_1695621908648/work
build==0.9.0
cached-property @ file:///home/conda/feedstock_root/build_artifacts/cached_property_1615209429212/work
certifi @ file:///home/conda/feedstock_root/build_artifacts/certifi_1700303426725/work/certifi
cffi @ file:///Users/runner/miniforge3/conda-bld/cffi_1696001836291/work
charset-normalizer @ file:///home/conda/feedstock_root/build_artifacts/charset-normalizer_1698833585322/work
chromedriver-binary @ file:///Users/runner/miniforge3/conda-bld/python-chromedriver-binary_1685624754200/work
click @ file:///home/conda/feedstock_root/build_artifacts/click_1692311806742/work
click-default-group @ file:///home/conda/feedstock_root/build_artifacts/click-default-group_1691239292067/work
colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1666700638685/work
colorcet @ file:///home/conda/feedstock_root/build_artifacts/colorcet_1664843244467/work
comm @ file:///home/conda/feedstock_root/build_artifacts/comm_1691044910542/work
contourpy @ file:///Users/runner/miniforge3/conda-bld/contourpy_1699041448398/work
cryptography @ file:///Users/runner/miniforge3/conda-bld/cryptography-split_1701145268638/work
cycler @ file:///home/conda/feedstock_root/build_artifacts/cycler_1696677705766/work
debugpy @ file:///Users/runner/miniforge3/conda-bld/debugpy_1695534361821/work
decorator @ file:///home/conda/feedstock_root/build_artifacts/decorator_1641555617451/work
defusedxml @ file:///home/conda/feedstock_root/build_artifacts/defusedxml_1615232257335/work
DESlib==0.3.5
distlib @ file:///home/conda/feedstock_root/build_artifacts/distlib_1689598491484/work
doc8 @ file:///home/conda/feedstock_root/build_artifacts/doc8_1672781427882/work
docutils @ file:///Users/runner/miniforge3/conda-bld/docutils_1695300523252/work
entrypoints @ file:///home/conda/feedstock_root/build_artifacts/entrypoints_1643888246732/work
esbonio==0.15.0
et-xmlfile @ file:///home/conda/feedstock_root/build_artifacts/et_xmlfile_1674664118162/work
exceptiongroup @ file:///home/conda/feedstock_root/build_artifacts/exceptiongroup_1700579780973/work
executing @ file:///home/conda/feedstock_root/build_artifacts/executing_1698579936712/work
fastjsonschema @ file:///home/conda/feedstock_root/build_artifacts/python-fastjsonschema_1700055509243/work/dist
filelock @ file:///home/conda/feedstock_root/build_artifacts/filelock_1698714947081/work
flake8 @ file:///home/conda/feedstock_root/build_artifacts/flake8_1690833614949/work
flit_core @ file:///home/conda/feedstock_root/build_artifacts/flit-core_1684084314667/work/source/flit_core
fonttools @ file:///Users/runner/miniforge3/conda-bld/fonttools_1700737136534/work
fqdn @ file:///home/conda/feedstock_root/build_artifacts/fqdn_1638810296540/work/dist
furo @ file:///home/conda/feedstock_root/build_artifacts/furo_1694439085938/work
h11 @ file:///home/conda/feedstock_root/build_artifacts/h11_1664132893548/work
idna @ file:///home/conda/feedstock_root/build_artifacts/idna_1701026962277/work
imagesize @ file:///home/conda/feedstock_root/build_artifacts/imagesize_1656939531508/work
importlib-metadata @ file:///home/conda/feedstock_root/build_artifacts/importlib-metadata_1676330731378/work
importlib-resources @ file:///home/conda/feedstock_root/build_artifacts/importlib_resources_1699364556997/work
incremental @ file:///home/conda/feedstock_root/build_artifacts/incremental_1665859450441/work
iniconfig @ file:///home/conda/feedstock_root/build_artifacts/iniconfig_1673103042956/work
ipykernel @ file:///Users/runner/miniforge3/conda-bld/ipykernel_1698244280508/work
ipython @ file:///home/conda/feedstock_root/build_artifacts/ipython_1701092366260/work
ipython-genutils==0.2.0
ipywidgets @ file:///home/conda/feedstock_root/build_artifacts/ipywidgets_1694607144474/work
isoduration @ file:///home/conda/feedstock_root/build_artifacts/isoduration_1638811571363/work/dist
isort @ file:///home/conda/feedstock_root/build_artifacts/isort_1675033873689/work
jedi @ file:///home/conda/feedstock_root/build_artifacts/jedi_1696326070614/work
Jinja2 @ file:///home/conda/feedstock_root/build_artifacts/jinja2_1654302431367/work
joblib @ file:///home/conda/feedstock_root/build_artifacts/joblib_1691577114857/work
jsonpointer @ file:///Users/runner/miniforge3/conda-bld/jsonpointer_1695397490390/work
jsonschema @ file:///home/conda/feedstock_root/build_artifacts/jsonschema-meta_1700159890288/work
jsonschema-specifications @ file:///home/conda/feedstock_root/build_artifacts/jsonschema-specifications_1700059145511/work
-e git+ssh://git@github.com/juaml/julearn.git@f9e0c7c7c6e7652b10e935883f78fce3b1d4f950#egg=julearn
-e git+ssh://git@github.com/juaml/julearn-sandbox.git@97dbd4a911253b48fa06fc3398cc42ba6fa5593c#egg=julearn_sandbox
jupyter @ file:///home/conda/feedstock_root/build_artifacts/jupyter_1696255489086/work
jupyter-bokeh @ file:///home/conda/feedstock_root/build_artifacts/jupyter_bokeh_1678841521825/work
jupyter-console @ file:///home/conda/feedstock_root/build_artifacts/jupyter_console_1678118109161/work
jupyter-events @ file:///home/conda/feedstock_root/build_artifacts/jupyter_events_1699285872613/work
jupyter_client @ file:///home/conda/feedstock_root/build_artifacts/jupyter_client_1699283905679/work
jupyter_core @ file:///Users/runner/miniforge3/conda-bld/jupyter_core_1698673724557/work
jupyter_server @ file:///home/conda/feedstock_root/build_artifacts/jupyter_server_1701102073871/work
jupyter_server_terminals @ file:///home/conda/feedstock_root/build_artifacts/jupyter_server_terminals_1673491454549/work
jupyterlab-widgets @ file:///home/conda/feedstock_root/build_artifacts/jupyterlab_widgets_1694598704522/work
jupyterlab_pygments @ file:///home/conda/feedstock_root/build_artifacts/jupyterlab_pygments_1700744013163/work
kiwisolver @ file:///Users/runner/miniforge3/conda-bld/kiwisolver_1695380058985/work
linkify-it-py @ file:///home/conda/feedstock_root/build_artifacts/linkify-it-py_1651923627081/work
lxml @ file:///Users/runner/miniforge3/conda-bld/lxml_1671013771134/work
Markdown @ file:///home/conda/feedstock_root/build_artifacts/markdown_1698797478597/work
markdown-it-py @ file:///home/conda/feedstock_root/build_artifacts/markdown-it-py_1686175045316/work
MarkupSafe @ file:///Users/runner/miniforge3/conda-bld/markupsafe_1695367660391/work
matplotlib @ file:///Users/runner/miniforge3/conda-bld/matplotlib-suite_1700509932345/work
matplotlib-inline @ file:///home/conda/feedstock_root/build_artifacts/matplotlib-inline_1660814786464/work
mccabe @ file:///home/conda/feedstock_root/build_artifacts/mccabe_1643049622439/work
mdit-py-plugins @ file:///home/conda/feedstock_root/build_artifacts/mdit-py-plugins_1686175351422/work
mdurl @ file:///home/conda/feedstock_root/build_artifacts/mdurl_1639515908913/work
mistune @ file:///home/conda/feedstock_root/build_artifacts/mistune_1698947099619/work
munkres==1.1.4
mypy-extensions @ file:///home/conda/feedstock_root/build_artifacts/mypy_extensions_1675543315189/work
myst-parser @ file:///home/conda/feedstock_root/build_artifacts/myst-parser_1686686235198/work
nbclassic @ file:///home/conda/feedstock_root/build_artifacts/nbclassic_1683202081046/work
nbclient @ file:///home/conda/feedstock_root/build_artifacts/nbclient_1684790896106/work
nbconvert @ file:///home/conda/feedstock_root/build_artifacts/nbconvert-meta_1699285928227/work
nbformat @ file:///home/conda/feedstock_root/build_artifacts/nbformat_1690814868471/work
nest-asyncio @ file:///home/conda/feedstock_root/build_artifacts/nest-asyncio_1697083700168/work
notebook @ file:///home/conda/feedstock_root/build_artifacts/notebook_1680870634737/work
notebook_shim @ file:///home/conda/feedstock_root/build_artifacts/notebook-shim_1682360583588/work
numpy @ file:///Users/runner/miniforge3/conda-bld/numpy_1700874570898/work/dist/numpy-1.26.2-cp311-cp311-macosx_11_0_arm64.whl#sha256=6a1afc4f3b7776e43c5d2749d8fae541f47a49ecd1ec0fff58a7ea345a7a67b5
numpydoc @ file:///home/conda/feedstock_root/build_artifacts/numpydoc_1665273484262/work
openpyxl @ file:///Users/runner/miniforge3/conda-bld/openpyxl_1682610938393/work
outcome @ file:///home/conda/feedstock_root/build_artifacts/outcome_1698324044871/work
overrides @ file:///home/conda/feedstock_root/build_artifacts/overrides_1691338815398/work
packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1696202382185/work
pandas @ file:///Users/runner/miniforge3/conda-bld/pandas_1699670234807/work
pandocfilters @ file:///home/conda/feedstock_root/build_artifacts/pandocfilters_1631603243851/work
panel @ file:///home/conda/feedstock_root/build_artifacts/panel_1700689401726/work
param @ file:///home/conda/feedstock_root/build_artifacts/param_1699478026279/work
parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1638334955874/work
pathspec @ file:///home/conda/feedstock_root/build_artifacts/pathspec_1690597952537/work
patsy @ file:///home/conda/feedstock_root/build_artifacts/patsy_1665356157073/work
pbr @ file:///home/conda/feedstock_root/build_artifacts/pbr_1699384704298/work
pep517==0.13.0
pexpect @ file:///home/conda/feedstock_root/build_artifacts/pexpect_1667297516076/work
pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1602536217715/work
Pillow @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_ccx0_h9rkg/croot/pillow_1696580032390/work
pkgutil_resolve_name @ file:///home/conda/feedstock_root/build_artifacts/pkgutil-resolve-name_1694617248815/work
platformdirs @ file:///home/conda/feedstock_root/build_artifacts/platformdirs_1699715570510/work
pluggy @ file:///home/conda/feedstock_root/build_artifacts/pluggy_1693086607691/work
ply==3.11
prometheus-client @ file:///home/conda/feedstock_root/build_artifacts/prometheus_client_1700579315247/work
prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1699963054032/work
psutil @ file:///Users/runner/miniforge3/conda-bld/psutil_1695367184494/work
ptyprocess @ file:///home/conda/feedstock_root/build_artifacts/ptyprocess_1609419310487/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
pure-eval @ file:///home/conda/feedstock_root/build_artifacts/pure_eval_1642875951954/work
py @ file:///home/conda/feedstock_root/build_artifacts/py_1636301881863/work
pycodestyle @ file:///home/conda/feedstock_root/build_artifacts/pycodestyle_1697202867721/work
pycparser @ file:///home/conda/feedstock_root/build_artifacts/pycparser_1636257122734/work
pyct==0.5.0
pydantic @ file:///home/conda/feedstock_root/build_artifacts/pydantic_1700669197061/work
pydantic_core @ file:///Users/runner/miniforge3/conda-bld/pydantic-core_1700664103380/work
pyflakes @ file:///home/conda/feedstock_root/build_artifacts/pyflakes_1690656279496/work
pygls==0.13.1
Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1700607939962/work
pyobjc-core @ file:///Users/runner/miniforge3/conda-bld/pyobjc-core_1695560110143/work
pyobjc-framework-Cocoa @ file:///Users/runner/miniforge3/conda-bld/pyobjc-framework-cocoa_1695716633957/work
pyOpenSSL @ file:///home/conda/feedstock_root/build_artifacts/pyopenssl_1698795453264/work
pyparsing @ file:///home/conda/feedstock_root/build_artifacts/pyparsing_1690737849915/work
PyQt5-sip==12.12.2
pyrsistent @ file:///Users/runner/miniforge3/conda-bld/pyrsistent_1698754013865/work
PySocks @ file:///home/conda/feedstock_root/build_artifacts/pysocks_1661604839144/work
pyspellchecker==0.7.0
pytest @ file:///home/conda/feedstock_root/build_artifacts/pytest_1698233724984/work
pytest-lazy-fixture==0.6.3
python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/python-dateutil_1626286286081/work
python-json-logger @ file:///home/conda/feedstock_root/build_artifacts/python-json-logger_1677079630776/work
pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1693930252784/work
pyviz_comms @ file:///home/conda/feedstock_root/build_artifacts/pyviz_comms_1692264662742/work
PyYAML @ file:///Users/runner/miniforge3/conda-bld/pyyaml_1695373486380/work
pyzmq @ file:///Users/runner/miniforge3/conda-bld/pyzmq_1698062469480/work
qtconsole @ file:///home/conda/feedstock_root/build_artifacts/qtconsole-base_1700168901209/work
QtPy @ file:///home/conda/feedstock_root/build_artifacts/qtpy_1698112029416/work
referencing @ file:///home/conda/feedstock_root/build_artifacts/referencing_1700053204647/work
requests @ file:///home/conda/feedstock_root/build_artifacts/requests_1684774241324/work
restructuredtext-lint @ file:///home/conda/feedstock_root/build_artifacts/restructuredtext_lint_1645724685739/work
rfc3339-validator @ file:///home/conda/feedstock_root/build_artifacts/rfc3339-validator_1638811747357/work
rfc3986-validator @ file:///home/conda/feedstock_root/build_artifacts/rfc3986-validator_1598024191506/work
rich @ file:///home/conda/feedstock_root/build_artifacts/rich-split_1700160075651/work/dist
rpds-py @ file:///Users/runner/miniforge3/conda-bld/rpds-py_1700527066384/work
rstcheck @ file:///home/conda/feedstock_root/build_artifacts/rstcheck_1698390827281/work
rstcheck-core @ file:///home/conda/feedstock_root/build_artifacts/rstcheck-core_1700333089305/work
ruff @ file:///Users/runner/miniforge3/conda-bld/ruff_1700256074653/work
scikit-learn==1.3.1
scikit-rvm @ https://github.com/JamesRitchie/scikit-rvm/archive/master.zip
SciPy @ file:///Users/runner/miniforge3/conda-bld/scipy-split_1700812589137/work/dist/scipy-1.11.4-cp311-cp311-macosx_11_0_arm64.whl#sha256=7f8fc22aa24cb1ee5318d88f2162f00440d915ebd87d725a05a0fccec9246fb9
seaborn @ file:///home/conda/feedstock_root/build_artifacts/seaborn-split_1696262444380/work
selenium @ file:///home/conda/feedstock_root/build_artifacts/selenium_1700158653787/work
Send2Trash @ file:///Users/runner/miniforge3/conda-bld/send2trash_1682601407921/work
shellingham @ file:///home/conda/feedstock_root/build_artifacts/shellingham_1698144360966/work
sip @ file:///Users/runner/miniforge3/conda-bld/sip_1697300467227/work
six @ file:///home/conda/feedstock_root/build_artifacts/six_1620240208055/work
sniffio @ file:///home/conda/feedstock_root/build_artifacts/sniffio_1662051266223/work
snowballstemmer @ file:///home/conda/feedstock_root/build_artifacts/snowballstemmer_1637143057757/work
sortedcontainers @ file:///home/conda/feedstock_root/build_artifacts/sortedcontainers_1621217038088/work
soupsieve @ file:///home/conda/feedstock_root/build_artifacts/soupsieve_1693929250441/work
Sphinx @ file:///home/conda/feedstock_root/build_artifacts/sphinx_1694647393084/work
sphinx-basic-ng @ file:///home/conda/feedstock_root/build_artifacts/sphinx-basic-ng_1690474916004/work
sphinx-copybutton==0.5.2
sphinx-gallery==0.13.0
sphinx-multiversion==0.2.4
sphinx-rtd-theme @ file:///home/conda/feedstock_root/build_artifacts/sphinx_rtd_theme_1701183475238/work
sphinx_inline_tabs @ file:///home/conda/feedstock_root/build_artifacts/sphinx-inline-tabs_1682112621951/work
sphinxcontrib-applehelp @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-applehelp_1692039578432/work
sphinxcontrib-devhelp @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-devhelp_1692039587698/work
sphinxcontrib-htmlhelp @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-htmlhelp_1692039590609/work
sphinxcontrib-jquery @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-jquery_1678808969227/work
sphinxcontrib-jsmath==1.0.1
sphinxcontrib-qthelp @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-qthelp_1692039556837/work
sphinxcontrib-serializinghtml @ file:///home/conda/feedstock_root/build_artifacts/sphinxcontrib-serializinghtml_1692579968530/work
stack-data @ file:///home/conda/feedstock_root/build_artifacts/stack_data_1669632077133/work
statsmodels @ file:///Users/runner/miniforge3/conda-bld/statsmodels_1696548130972/work
stevedore @ file:///home/conda/feedstock_root/build_artifacts/stevedore_1684261909860/work
terminado @ file:///Users/runner/miniforge3/conda-bld/terminado_1699810180257/work
threadpoolctl @ file:///home/conda/feedstock_root/build_artifacts/threadpoolctl_1689261241048/work
tinycss2 @ file:///home/conda/feedstock_root/build_artifacts/tinycss2_1666100256010/work
toml @ file:///home/conda/feedstock_root/build_artifacts/toml_1604308577558/work
tomli @ file:///home/conda/feedstock_root/build_artifacts/tomli_1644342247877/work
tornado @ file:///Users/runner/miniforge3/conda-bld/tornado_1695373481350/work
towncrier==22.12.0
tox @ file:///home/conda/feedstock_root/build_artifacts/tox_1668431778215/work
tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1691671248568/work
traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1675110562325/work
trio @ file:///Users/runner/miniforge3/conda-bld/trio_1699332590961/work
trio-websocket @ file:///home/conda/feedstock_root/build_artifacts/trio-websocket_1695816857197/work/dist
typeguard==2.13.3
typer @ file:///home/conda/feedstock_root/build_artifacts/typer_1683029246636/work
types-docutils @ file:///home/conda/feedstock_root/build_artifacts/types-docutils_1692182146194/work
types-python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/types-python-dateutil_1689882883784/work
typing-utils @ file:///home/conda/feedstock_root/build_artifacts/typing_utils_1622899189314/work
typing_extensions @ file:///home/conda/feedstock_root/build_artifacts/typing_extensions_1695040754690/work
tzdata @ file:///home/conda/feedstock_root/build_artifacts/python-tzdata_1680081134351/work
uc-micro-py @ file:///home/conda/feedstock_root/build_artifacts/uc-micro-py_1608058642472/work
uri-template @ file:///home/conda/feedstock_root/build_artifacts/uri-template_1688655812972/work/dist
urllib3 @ file:///home/conda/feedstock_root/build_artifacts/urllib3_1699933488691/work
virtualenv @ file:///home/conda/feedstock_root/build_artifacts/virtualenv_1700749121601/work
wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1700607916581/work
webcolors @ file:///home/conda/feedstock_root/build_artifacts/webcolors_1679900785843/work
webencodings @ file:///home/conda/feedstock_root/build_artifacts/webencodings_1694681268211/work
websocket-client @ file:///home/conda/feedstock_root/build_artifacts/websocket-client_1696770128353/work
widgetsnbextension @ file:///home/conda/feedstock_root/build_artifacts/widgetsnbextension_1694598693908/work
wsproto @ file:///home/conda/feedstock_root/build_artifacts/wsproto_1661356345548/work
xyzservices @ file:///home/conda/feedstock_root/build_artifacts/xyzservices_1698325309404/work
zipp @ file:///home/conda/feedstock_root/build_artifacts/zipp_1695255097490/work
```


### Relevant log output

_No response_

### Anything else?

_No response_