### PR TITLE
[MAINT]: Support `pytest >= 8.0.0`

### DIFF
--- a/docs/changes/newsfragments/251.misc
+++ b/docs/changes/newsfragments/251.misc
@@ -1,0 +1,1 @@
+Remove ``pytest-lazy-fixture`` and enable support for ``pytest >= 8.0.0`` by `Synchon Mandal`_

--- a/julearn/conftest.py
+++ b/julearn/conftest.py
@@ -131,7 +131,7 @@ def X_types_iris(request: FixtureRequest) -> Optional[Dict]:
 
 
 @fixture(params=["rf", "svm", "gauss", "ridge"], scope="function")
-def models_all_problem_types(request: FixtureRequest) -> str:
+def model(request: FixtureRequest) -> str:
     """Return different models that work with classification and regression.
 
     Parameters
@@ -149,7 +149,7 @@ def models_all_problem_types(request: FixtureRequest) -> str:
 
 
 @fixture(params=["regression", "classification"], scope="function")
-def all_problem_types(request: FixtureRequest) -> str:
+def problem_type(request: FixtureRequest) -> str:
     """Return different problem types.
 
     Parameters
@@ -245,7 +245,7 @@ def get_tuning_params() -> Callable:
     ],
     scope="function",
 )
-def preprocessing(request: FixtureRequest) -> Union[str, List[str]]:
+def preprocess(request: FixtureRequest) -> Union[str, List[str]]:
     """Return different preprocessing steps.
 
     Parameters

--- a/julearn/conftest.py
+++ b/julearn/conftest.py
@@ -160,7 +160,7 @@ def problem_type(request: FixtureRequest) -> str:
     Returns
     -------
     str
-        The problem type (one of {"regression", "classification"}).
+        The problem type.
 
     """
 

--- a/julearn/models/tests/test_dynamic.py
+++ b/julearn/models/tests/test_dynamic.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from pytest import FixtureRequest, fixture
-from pytest_lazyfixture import lazy_fixture
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import ShuffleSplit, train_test_split
 
@@ -64,7 +63,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
     ],
     scope="module",
 )
-def all_deslib_algorithms(request: FixtureRequest) -> str:
+def algo_name(request: FixtureRequest) -> str:
     """Return different algorithms for the iris dataset features.
 
     Parameters
@@ -81,10 +80,6 @@ def all_deslib_algorithms(request: FixtureRequest) -> str:
     return request.param
 
 
-@pytest.mark.parametrize(
-    "algo_name",
-    [lazy_fixture("all_deslib_algorithms")],
-)
 @pytest.mark.skip("Deslib is not compatible with new python. Waiting for PR.")
 def test_algorithms(
     df_iris: pd.DataFrame,

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -5,7 +5,7 @@
 # License: AGPL
 
 import warnings
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 
 import pandas as pd
 import pytest
@@ -23,7 +23,7 @@ from julearn.transformers import get_transformer
 
 
 def test_construction_working(
-    model: str, preprocess: List[str], problem_type: str
+    model: str, preprocess: Union[str, List[str]], problem_type: str
 ) -> None:
     """Test that the pipeline constructions works as expected.
 
@@ -31,7 +31,7 @@ def test_construction_working(
     ----------
     model : str
         The model to test.
-    preprocess : List[str]
+    preprocess : str or list of str
         The preprocessing steps to test.
     problem_type : str
         The problem type to test.
@@ -72,7 +72,7 @@ def test_fit_and_transform_no_error(
     X_iris: pd.DataFrame,  # noqa: N803
     y_iris: pd.Series,
     model: str,
-    preprocess: List[str],
+    preprocess: Union[str, List[str]],
     problem_type: str,
 ) -> None:
     """Test that the pipeline fit and transform does not give an error.
@@ -85,7 +85,7 @@ def test_fit_and_transform_no_error(
         The iris dataset target variable.
     model : str
         The model to test.
-    preprocess : List[str]
+    preprocess : str or list of str
         The preprocessing steps to test.
     problem_type : str
         The problem type to test.
@@ -103,7 +103,7 @@ def test_fit_and_transform_no_error(
 def test_hyperparameter_tuning(
     X_types_iris: Dict[str, List[str]],  # noqa: N803
     model: str,
-    preprocess: List[str],
+    preprocess: Union[str, List[str]],
     problem_type: str,
     get_tuning_params: Callable,
     search_params: Dict[str, List],
@@ -112,11 +112,11 @@ def test_hyperparameter_tuning(
 
     Parameters
     ----------
-    X_types_iris : Dict[str, List[str]]
+    X_types_iris : dict
         The iris dataset features types.
     model : str
         The model to test.
-    preprocess : List[str]
+    preprocess : str or list of str
         The preprocessing steps to test.
     problem_type : str
         The problem type to test.

--- a/julearn/pipeline/test/test_pipeline_creator.py
+++ b/julearn/pipeline/test/test_pipeline_creator.py
@@ -9,7 +9,6 @@ from typing import Callable, Dict, List
 
 import pandas as pd
 import pytest
-from pytest_lazyfixture import lazy_fixture
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
@@ -23,14 +22,6 @@ from julearn.pipeline.pipeline_creator import JuColumnTransformer
 from julearn.transformers import get_transformer
 
 
-@pytest.mark.parametrize(
-    "model,preprocess,problem_type",
-    [
-        lazy_fixture(
-            ["models_all_problem_types", "preprocessing", "all_problem_types"]
-        )
-    ],
-)
 def test_construction_working(
     model: str, preprocess: List[str], problem_type: str
 ) -> None:
@@ -77,14 +68,6 @@ def test_construction_working(
     assert len(preprocess) + 2 == len(pipeline.steps)
 
 
-@pytest.mark.parametrize(
-    "model,preprocess,problem_type",
-    [
-        lazy_fixture(
-            ["models_all_problem_types", "preprocessing", "all_problem_types"]
-        )
-    ],
-)
 def test_fit_and_transform_no_error(
     X_iris: pd.DataFrame,  # noqa: N803
     y_iris: pd.Series,
@@ -117,14 +100,6 @@ def test_fit_and_transform_no_error(
     pipeline[:-1].transform(X_iris)
 
 
-@pytest.mark.parametrize(
-    "model,preprocess,problem_type",
-    [
-        lazy_fixture(
-            ["models_all_problem_types", "preprocessing", "all_problem_types"]
-        ),
-    ],
-)
 def test_hyperparameter_tuning(
     X_types_iris: Dict[str, List[str]],  # noqa: N803
     model: str,

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ python =
 skip_install = false
 deps =
     pytest
+    seaborn
 commands =
     pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,7 @@ python =
 [testenv]
 skip_install = false
 deps =
-    pytest<8.0.0
-    pytest-lazy-fixture
-    seaborn
-    deslib
-    panel>=1.0.0b1
-    bokeh>=3.0.0
-    param
+    pytest
 commands =
     pytest
 
@@ -39,8 +33,7 @@ commands =
 [testenv:test]
 skip_install = false
 deps =
-    pytest<8.0.0
-    pytest-lazy-fixture
+    pytest
     seaborn
     deslib
     panel>=1.0.0b1
@@ -52,8 +45,7 @@ commands =
 [testenv:coverage]
 skip_install = false
 deps =
-    pytest<8.0.0
-    pytest-lazy-fixture
+    pytest
     pytest-cov
     seaborn
     deslib


### PR DESCRIPTION
`pytest-lazy-fixture` breaks in Pytest 8.0.0: https://github.com/TvoroG/pytest-lazy-fixture/issues/65

Ideally, we should ditch this dependency as it is not actively maintained anymore and I do believe that we can achieve the same goal in a different way. It also creates an issue with other tools as the order of the tests is not usually maintained across runs.