### PR TITLE
[MAINT]: Prepare for scikit-learn 1.4

### DIFF
--- a/docs/changes/newsfragments/244.misc
+++ b/docs/changes/newsfragments/244.misc
@@ -1,0 +1,1 @@
+Add support for ``scikit-learn 1.4.x`` by `Synchon Mandal`_

--- a/julearn/base/estimators.py
+++ b/julearn/base/estimators.py
@@ -10,7 +10,16 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.metaestimators import available_if
-from sklearn.utils.validation import _check_fit_params
+
+
+try:  # sklearn < 1.4.0
+    from sklearn.utils.validation import _check_fit_params
+
+    fit_params_checker = _check_fit_params
+except ImportError:  # sklearn >= 1.4.0
+    from sklearn.utils.validation import _check_method_params
+
+    fit_params_checker = _check_method_params
 
 from ..base.column_types import make_type_selector
 from ..utils import raise_error
@@ -238,7 +247,7 @@ class JuTransformer(JuBaseEstimator, TransformerMixin):
         ).index.values
         _X = X.loc[idx, :]
         _y = y if y is None else y.loc[idx]
-        fit_params = _check_fit_params(X, fit_params, indices=idx)
+        fit_params = fit_params_checker(X, fit_params, indices=idx)
 
         return dict(X=_X, y=_y, **fit_params)
 

--- a/julearn/pipeline/test/test_target_pipeline.py
+++ b/julearn/pipeline/test/test_target_pipeline.py
@@ -196,6 +196,7 @@ def test_target_noninverse(df_iris, X_iris):  # noqa: N803
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        warnings.simplefilter(action="ignore", category=FutureWarning)
         run_cross_validation(
             X=X,
             y="species",

--- a/julearn/tests/test_api.py
+++ b/julearn/tests/test_api.py
@@ -4,6 +4,7 @@
 #          Sami Hamdan <s.hamdan@fz-juelich.de>
 # License: AGPL
 
+import platform
 from pathlib import Path
 
 import joblib
@@ -208,7 +209,15 @@ def test_run_cv_simple_binary_errors(
     api_params = {"model": "svm", "problem_type": "classification"}
     sklearn_model = SVC()
 
-    with pytest.warns(UserWarning, match="Target is multiclass but average"):
+    if (
+        platform.python_version_tuple()[0] == "3"
+        and int(platform.python_version_tuple()[1]) > 8
+    ):
+        user_warning_msg = "Scoring failed."
+    else:
+        user_warning_msg = "Target is multiclass but average"
+
+    with pytest.warns(UserWarning, match=user_warning_msg):
         do_scoring_test(
             X,
             y,

--- a/julearn/utils/typing.py
+++ b/julearn/utils/typing.py
@@ -16,18 +16,26 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-from sklearn.metrics._scorer import (
-    _PredictScorer,
-    _ProbaScorer,
-    _ThresholdScorer,
-)
+
+
+try:  # sklearn < 1.4.0
+    from sklearn.metrics._scorer import (
+        _PredictScorer,
+        _ProbaScorer,
+        _ThresholdScorer,
+    )
+
+    ScorerLike = Union[_ProbaScorer, _ThresholdScorer, _PredictScorer]
+except ImportError:  # sklearn >= 1.4.0
+    from sklearn.metrics._scorer import _Scorer
+
+    ScorerLike = _Scorer
+
 
 from ..base import ColumnTypes
 
 
 DataLike = Union[np.ndarray, pd.DataFrame, pd.Series]
-
-ScorerLike = Union[_ProbaScorer, _ThresholdScorer, _PredictScorer]
 
 
 @runtime_checkable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ classifiers = [
 dependencies = [
     "numpy>=1.24,<1.27",
     "pandas>=1.5.0,<2.2",
-    "scikit-learn>=1.2.0,<1.4",
     "statsmodels>=0.13,<0.15",
+    "scikit-learn>=1.2.0,<1.5.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The first release candidate for scikit-learn 1.4 is available as from 21.12.2023.

We should test compatibility with julearn.