### PR TITLE
[CI]: Mark stale and close issues after inactivity

### DIFF
--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 30
+          days-before-close: 7
+          any-of-issue-labels: question

--- a/docs/changes/newsfragments/224.misc
+++ b/docs/changes/newsfragments/224.misc
@@ -1,0 +1,1 @@
+Add a new GitHub Action to mark stale issues by `Synchon Mandal`_


### PR DESCRIPTION
### Which feature do you want to include?

Use this action: https://github.com/marketplace/actions/close-stale-issues

To mark issues as stale and later on close them if they have the label _question_ (meaning waiting for a response) and they were not replied in 30 days (stale) and then close (7 more days).

### How do you imagine this integrated in julearn?

```yaml
name: 'Close stale issues and PRs'
on:
  schedule:
    - cron: '30 1 * * *'

jobs:
  stale:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/stale@v8
        with:
          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
          days-before-stale: 30
          days-before-close: 7
          any-of-issue-labels: question
```

### Do you have a sample code that implements this outside of julearn?

_No response_

### Anything else to say?

_No response_