### PR TITLE
[MAINT]: Add `julearn` to `conda-forge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![PyPI](https://img.shields.io/pypi/v/julearn?style=flat-square)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/julearn?style=flat-square)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/julearn?style=flat-square)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/julearn/badges/version.svg)](https://anaconda.org/conda-forge/julearn)
 ![GitHub](https://img.shields.io/github/license/juaml/julearn?style=flat-square)
 ![Codecov](https://img.shields.io/codecov/c/github/juaml/julearn?style=flat-square)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
@@ -22,6 +23,12 @@ Use `pip` to install from PyPI like so:
 
 ```
 pip install julearn
+```
+
+You can also install via `conda`, like so:
+
+```
+conda install -c conda-forge julearn
 ```
 
 ## Licensing

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,7 +22,7 @@ Running the examples require:
 * ``panel>=1.0.0b1``
 * ``param>=1.11.0``
 
-Depending on the installation method (e.g. the `pip install` option below),
+Depending on the installation method (e.g. the ``pip install`` option below),
 these packages might be installed automatically. It is nevertheless good to be
 aware of these dependencies as installing ``julearn`` might lead to changes in
 these packages.
@@ -47,16 +47,22 @@ Installing
     developer version until we release the next stable ``julearn`` version.
 
 
-Depending on your aimed usage of ``julearn`` you have two different options
+Depending on your aimed usage of ``julearn`` you have different options
 how to install ``julearn``:
 
 #. Install the *latest release*: Likely most suitable for most
    **end users**. This is done by installing the latest stable release from
-   PyPI.
+   PyPI:
 
    .. code-block:: bash
 
        pip install -U julearn
+
+   or via ``conda`` like so:
+
+   .. code-block:: bash
+
+     conda install -c conda-forge julearn
 
 #. Install the *latest pre-relase*: This version will have the
    **latest updates**. However, it is still under development and not yet

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -96,5 +96,5 @@ The following optional dependencies are available:
   module is not compatible with newer Python versions and it is unmaintained.
 * ``skopt``: Using the ``"bayes"`` searcher (:class:`~skopt.BayesSearchCV`)
   requires the `scikit-optimize`_ package.
-* ``optuna``: Using the ``"optuna"`` searcher (:class:`~optuna_integration.sklearn.OptunaSearchCV`) requires the `optuna`_ and `optuna_integration`_ packages.
+* ``optuna``: Using the ``"optuna"`` searcher (:class:`~optuna_integration.sklearn.OptunaSearchCV`) requires the `Optuna`_ and `optuna_integration`_ packages.
 * ``all``: Install all optional functional dependencies (except ``deslib``).

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -12,15 +12,15 @@ packages:
 
 * ``numpy>=1.24,<1.27``
 * ``pandas>=1.5.0,<2.2``
-* ``scikit-learn>=1.2,<1.4``
+* ``scikit-learn>=1.2.0,<1.5.0``
 * ``statsmodels>=0.13,<0.15``
 
 Running the examples require:
 
 * ``seaborn>=0.12.2,<0.13``
 * ``bokeh>=3.0.0``
-* ``panel>=1.0.0b1``
-* ``param>=1.11.0``
+* ``panel>=1.3.0``
+* ``param>=2.0.0``
 
 Depending on the installation method (e.g. the ``pip install`` option below),
 these packages might be installed automatically. It is nevertheless good to be
@@ -96,4 +96,5 @@ The following optional dependencies are available:
   module is not compatible with newer Python versions and it is unmaintained.
 * ``skopt``: Using the ``"bayes"`` searcher (:class:`~skopt.BayesSearchCV`)
   requires the `scikit-optimize`_ package.
+* ``optuna``: Using the ``"optuna"`` searcher (:class:`~optuna_integration.sklearn.OptunaSearchCV`) requires the `optuna`_ and `optuna_integration`_ packages.
 * ``all``: Install all optional functional dependencies (except ``deslib``).

--- a/docs/links.inc
+++ b/docs/links.inc
@@ -42,3 +42,4 @@
 .. _`DESlib`: https://github.com/scikit-learn-contrib/DESlib
 .. _`scikit-optimize`: https://scikit-optimize.readthedocs.io/en/stable/
 .. _`Optuna`: https://optuna.org
+.. _`optuna_integration`: https://github.com/optuna/optuna-integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,13 +69,11 @@ viz = [
     "bokeh>=3.0.0",
     "param>=2.0.0",
 ]
-
 skopt = ["scikit-optimize>=0.10.0,<0.11"]
 optuna = [
     "optuna>=3.6.0,<3.7",
     "optuna_integration>=3.6.0,<3.7",
 ]
-
 # Add all optional functional dependencies (skip deslib until its fixed)
 # This does not include dev/docs building dependencies
 all = ["julearn[viz,skopt,optuna]"]
@@ -226,7 +224,7 @@ showcontent = true
 name = "API Changes"
 showcontent = true
 
-## Configure pyright to ignore assigment types until scikit-learn stubs are updated
+## Configure pyright to ignore assignment types until scikit-learn stubs are updated
 [tool.pyright]
 reportAssignmentType = "none"
 exclude = [


### PR DESCRIPTION
Make `julearn` available via `conda` by adding recipe to [conda-forge](https://conda-forge.org) channel. This will enable users to install `julearn` via:
```shell
conda install -c conda-forge julearn
```