### PR TITLE
[ENH]: Optimise step wrapping

### DIFF
--- a/docs/changes/newsfragments/274.enh
+++ b/docs/changes/newsfragments/274.enh
@@ -1,0 +1,1 @@
+Optimise wrapping of steps and models in the pipeline only when a subset of features is being used, by `Fede Raimondo`_

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,3 +47,10 @@ Here you can find the comprehensive list of flags that can be set:
      - | Disable printing the list of expanded column names in ``X_types``.
        | If set to ``True``, the list of types of X will not be printed.
      - The user will not see the expanded ``X_types`` column names.
+   * - ``enable_parallel_column_transformers``
+     - | This flag enables parallel execution of column transformers by
+       | reverting to the default behaviour of scikit-learn
+       | (instead of using ``n_jobs=1``)
+       | If set to ``True``, the parameter will be set back to None.
+     - | Column transformers will be applied in parallel, using more resources.
+       | than expected.

--- a/examples/02_inspection/plot_preprocess.py
+++ b/examples/02_inspection/plot_preprocess.py
@@ -121,7 +121,7 @@ X_after_zscore = preprocess(model, X=X, data=df, until="zscore")
 fig, axes = plt.subplots(1, 2, figsize=(12, 6))
 sns.scatterplot(x=X[0], y=X[1], data=df, ax=axes[0])
 axes[0].set_title("Raw features")
-sns.scatterplot(x="pca__pca0", y="pca__pca1", data=X_after_pca, ax=axes[1])
+sns.scatterplot(x="pca0", y="pca1", data=X_after_pca, ax=axes[1])
 axes[1].set_title("PCA components")
 
 ###############################################################################

--- a/examples/04_confounds/run_return_confounds.py
+++ b/examples/04_confounds/run_return_confounds.py
@@ -172,4 +172,4 @@ scores
 # (including confounds and categorical variables).
 # Here we can see that the model is using 10 features (9 deconfounded features
 # and the confound).
-print(len(model.steps[-1][1].model.coef_))
+print(len(model.steps[-1][1].coef_))

--- a/examples/99_docs/run_model_inspection_docs.py
+++ b/examples/99_docs/run_model_inspection_docs.py
@@ -140,7 +140,7 @@ c_values = []
 for fold_inspector in inspector.folds:
     fold_model = fold_inspector.model
     c_values.append(
-        fold_model.get_fitted_params()["svm__model_"].get_params()["C"]
+        fold_model.get_fitted_params()["svm__C"]
     )
 
 ##############################################################################

--- a/julearn/config.py
+++ b/julearn/config.py
@@ -14,6 +14,7 @@ _global_config["disable_x_check"] = False
 _global_config["disable_xtypes_check"] = False
 _global_config["disable_x_verbose"] = False
 _global_config["disable_xtypes_verbose"] = False
+_global_config["enable_parallel_column_transformers"] = False
 
 
 def set_config(key: str, value: Any) -> None:

--- a/julearn/inspect/_pipeline.py
+++ b/julearn/inspect/_pipeline.py
@@ -63,11 +63,14 @@ class _EstimatorInspector:
                 ),
             }
 
-        return {
+        private_params = {
             param: val
             for param, val in all_params.items()
             if re.match(r"^[a-zA-Z].*[a-zA-Z0-9]*_$", param)
         }
+        out = self.get_params()
+        out.update(private_params)
+        return out
 
     @property
     def estimator(self):

--- a/julearn/inspect/tests/test_pipeline.py
+++ b/julearn/inspect/tests/test_pipeline.py
@@ -152,14 +152,25 @@ def test_steps(
 @pytest.mark.parametrize(
     "est,fitted_params",
     [
-        [MockTestEst(), {"param_0_": 0, "param_1_": 1}],
+        [
+            MockTestEst(),
+            {"hype_0": 0, "hype_1": 1, "param_0_": 0, "param_1_": 1},
+        ],
         [
             JuColumnTransformer(
                 "test",
                 MockTestEst(),  # type: ignore
                 "continuous",
             ),
-            {"param_0_": 0, "param_1_": 1},
+            {
+                "hype_0": 0,
+                "hype_1": 1,
+                "param_0_": 0,
+                "param_1_": 1,
+                "needed_types": None,
+                "row_select_col_type": None,
+                "row_select_vals": None,
+            },
         ],
     ],
 )
@@ -183,6 +194,9 @@ def test_inspect_estimator(
     assert est.get_params() == inspector.get_params()
     inspect_params = inspector.get_fitted_params()
     inspect_params.pop("column_transformer_", None)
+    inspect_params.pop("apply_to", None)
+    inspect_params.pop("transformer", None)
+    inspect_params.pop("name", None)
     assert fitted_params == inspect_params
 
 
@@ -196,8 +210,14 @@ def test_inspect_pipeline(df_iris: "pd.DataFrame") -> None:
 
     """
     expected_fitted_params = {
+        "jucolumntransformer__hype_0": 0,
+        "jucolumntransformer__hype_1": 1,
         "jucolumntransformer__param_0_": 0,
         "jucolumntransformer__param_1_": 1,
+        "jucolumntransformer__needed_types": None,
+        "jucolumntransformer__row_select_col_type": None,
+        "jucolumntransformer__row_select_vals": None,
+        "jucolumntransformer__name": "test",
     }
 
     pipe = (
@@ -216,6 +236,8 @@ def test_inspect_pipeline(df_iris: "pd.DataFrame") -> None:
     inspector = PipelineInspector(pipe)
     inspect_params = inspector.get_fitted_params()
     inspect_params.pop("jucolumntransformer__column_transformer_", None)
+    inspect_params.pop("jucolumntransformer__transformer", None)
+    inspect_params.pop("jucolumntransformer__apply_to", None)
     inspect_params = {
         key: val
         for key, val in inspect_params.items()

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -511,14 +511,18 @@ class PipelineCreator:
             logger.debug(f"\t Params to tune: {step_params_to_tune}")
 
             # Wrap in a JuTransformer if needed
-            if self.wrap and not isinstance(estimator, JuTransformer):
-                estimator = self._wrap_step(
-                    name,
-                    estimator,
-                    step_dict.apply_to,
-                    row_select_col_type=step_dict.row_select_col_type,
-                    row_select_vals=step_dict.row_select_vals,
-                )
+            if self.wrap:
+                if step_dict.apply_to not in [
+                    {"*"},
+                    {".*"},
+                ] and not isinstance(estimator, JuTransformer):
+                    estimator = self._wrap_step(
+                        name,
+                        estimator,
+                        step_dict.apply_to,
+                        row_select_col_type=step_dict.row_select_col_type,
+                        row_select_vals=step_dict.row_select_vals,
+                    )
 
             # Check if a step with the same name was already added
             pipeline_steps.append((name, estimator))
@@ -794,7 +798,7 @@ class PipelineCreator:
 
     @staticmethod
     def _is_transformer_step(
-        step: Union[str, EstimatorLike, TargetPipelineCreator]
+        step: Union[str, EstimatorLike, TargetPipelineCreator],
     ) -> bool:
         """Check if a step is a transformer."""
         if step in list_transformers():
@@ -805,7 +809,7 @@ class PipelineCreator:
 
     @staticmethod
     def _is_model_step(
-        step: Union[EstimatorLike, str, TargetPipelineCreator]
+        step: Union[EstimatorLike, str, TargetPipelineCreator],
     ) -> bool:
         """Check if a step is a model."""
         if step in list_models():

--- a/julearn/tests/test_api.py
+++ b/julearn/tests/test_api.py
@@ -1227,7 +1227,7 @@ def test_api_stacking_models() -> None:
     # The final model should be a stacking model im which the first estimator
     # is a grid search
     assert isinstance(
-        final.steps[1][1].model.estimators[0][1],  # type: ignore
+        final.steps[1][1].estimators[0][1],  # type: ignore
         GridSearchCV,
     )
 

--- a/julearn/transformers/ju_column_transformer.py
+++ b/julearn/transformers/ju_column_transformer.py
@@ -12,6 +12,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.utils.validation import check_is_fitted
 
 from ..base import ColumnTypesLike, JuTransformer, ensure_column_types
+from ..config import get_config
 from ..utils.logging import raise_error
 from ..utils.typing import DataLike, EstimatorLike
 
@@ -93,6 +94,9 @@ class JuColumnTransformer(JuTransformer):
             [(self.name, self.transformer, self.apply_to.to_type_selector())],
             verbose_feature_names_out=verbose_feature_names_out,
             remainder="passthrough",
+            n_jobs=None
+            if get_config("enable_parallel_column_transformers")
+            else 1,
         )
         self.column_transformer_.fit(X, y, **fit_params)
 


### PR DESCRIPTION
Currently, if a step does apply to anything different that `"continuous"`, it will be wrapped in a column transformer.

This is unoptimal as there is an overhead (which also invoves joblib) when this happens.

This PR fixes that by really checking the `apply_to` of the step with the `X_types` of the data. If the step really applies to a subset of features, then it will wrapped in a column transformer.

