### PR TITLE
Control parallel column transformer in filter columns

### DIFF
--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,21 @@
+Config
+======
+
+.. automodule:: julearn.config
+   :no-members:
+   :no-inherited-members:
+
+
+See :ref:`configuration` for more information on the flags that can be set.
+
+Functions
+---------
+
+.. currentmodule:: julearn.config
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+    set_config
+    get_config

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -18,3 +18,4 @@ API Reference
    prepare.rst
    stats.rst
    viz.rst
+   config.rst

--- a/docs/changes/newsfragments/277.enh
+++ b/docs/changes/newsfragments/277.enh
@@ -1,0 +1,1 @@
+Avoid parallel calls in :class:`.FilterColumns` if not specified by the user in the :mod:`.config` module by `Fede Raimondo`_

--- a/julearn/transformers/dataframe/filter_columns.py
+++ b/julearn/transformers/dataframe/filter_columns.py
@@ -55,8 +55,8 @@ class FilterColumns(JuTransformer):
 
     def _fit(
         self,
-        X: pd.DataFrame,
-        y: Optional[DataLike] = None,  # noqa: N803
+        X: pd.DataFrame,  # noqa: N803
+        y: Optional[DataLike] = None,
     ) -> "FilterColumns":
         """Fit the transformer.
 

--- a/julearn/transformers/dataframe/filter_columns.py
+++ b/julearn/transformers/dataframe/filter_columns.py
@@ -15,6 +15,7 @@ from ...base import (
     JuTransformer,
     ensure_column_types,
 )
+from ...config import get_config
 from ...utils.typing import DataLike
 
 
@@ -53,7 +54,9 @@ class FilterColumns(JuTransformer):
         )
 
     def _fit(
-        self, X: pd.DataFrame, y: Optional[DataLike] = None  # noqa: N803
+        self,
+        X: pd.DataFrame,
+        y: Optional[DataLike] = None,  # noqa: N803
     ) -> "FilterColumns":
         """Fit the transformer.
 
@@ -75,6 +78,9 @@ class FilterColumns(JuTransformer):
             transformers=[("keep", "passthrough", apply_to_selector)],
             remainder="drop",
             verbose_feature_names_out=False,
+            n_jobs=None
+            if get_config("enable_parallel_column_transformers")
+            else 1,
         )
         self.filter_columns_.fit(X, y)
         return self


### PR DESCRIPTION
Use the same logic for the `FilterColumns` as for the `JuColumnTransformer`, avoiding parallel calls if not specified by the user.