### PR TITLE
Delay message formatting

### DIFF
--- a/docs/changes/newsfragments/301.misc
+++ b/docs/changes/newsfragments/301.misc
@@ -1,0 +1,1 @@
+Delay log message formatting by `Fede Raimondo`_

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,15 +22,18 @@ Here you can find the comprehensive list of flags that can be set:
    :header-rows: 1
 
    * - Flag
+     - Value
      - Description
      - Potential problem(s)
    * - ``disable_x_check``
+     - ``False``
      - | Disable checking for unmatched column names in ``X``.
        | If set to ``True``, any element in ``X`` that is not present in the
        | dataframe will not result in an error.
      - | The user might think that a certain feature is used in the model when
        | it is not.
    * - ``disable_xtypes_check``
+     - ``False``
      - | Disable checking for missing/present ``X_types`` in the ``X`` parameter
        | of the :func:`.run_cross_validation` method.
        | If set to ``True``, the ``X_types`` parameter will not be checked for
@@ -40,14 +43,17 @@ Here you can find the comprehensive list of flags that can be set:
      - | The user might think that a certain feature is considered in the model
        | when it is not.
    * - ``disable_x_verbose``
+     - ``False``
      - | Disable printing the list of expanded column names in ``X``.
        | If set to ``True``, the list of column names will not be printed.
      - The user will not see the expanded column names in ``X``.
    * - ``disable_xtypes_verbose``
+     - ``False``
      - | Disable printing the list of expanded column names in ``X_types``.
        | If set to ``True``, the list of types of X will not be printed.
      - The user will not see the expanded ``X_types`` column names.
    * - ``enable_parallel_column_transformers``
+     - ``False``
      - | This flag enables parallel execution of column transformers by
        | reverting to the default behaviour of scikit-learn
        | (instead of using ``n_jobs=1``)
@@ -55,6 +61,13 @@ Here you can find the comprehensive list of flags that can be set:
      - | Column transformers will be applied in parallel, using more resources.
        | than expected.
    * - ``enable_auto_escape_parenthesis``
+     - ``True``
      - | This flag enables escaping parenthesis in column names.
      - | If column names include parenthesis, then they will be treated as regular
        | expression metacharacters and not regular characters.
+   * - ``max_x_logs``
+     - ``100``
+     - | This flag sets the maximum number of columns in ``X`` for which the
+       | column names will be printed.
+     - | If ``X`` has more columns than this value, the column names will
+       | not be printed, and a the number of columns will be displayed instead.

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -24,6 +24,7 @@ from .pipeline.merger import merge_pipelines
 from .prepare import check_consistency, prepare_input_data
 from .scoring import check_scoring
 from .utils import _compute_cvmdsum, logger, raise_error
+from .utils.logging import DelayedFmtMessage as __
 from .utils.typing import CVLike
 
 
@@ -185,7 +186,7 @@ def _validate_api_params(  # noqa: C901
     if seed is not None:
         # If a seed is passed, use it, otherwise do not do anything. User
         # might have set the seed outside of the library
-        logger.info(f"Setting random seed to {seed}")
+        logger.info(__("Setting random seed to {seed}", seed=seed))
         np.random.seed(seed)
 
     # Interpret the input data and prepare it to be used with the library
@@ -341,18 +342,32 @@ def _validate_api_params(  # noqa: C901
 
     # Log some information
     logger.info("= Data Information =")
-    logger.info(f"\tProblem type: {problem_type}")
-    logger.info(f"\tNumber of samples: {len(df_X)}")
-    logger.info(f"\tNumber of features: {len(df_X.columns)}")
+    logger.info(
+        __("\tProblem type: {problem_type}", problem_type=problem_type)
+    )
+    logger.info(__("\tNumber of samples: {n_samples}", n_samples=len(df_X)))
+    logger.info(
+        __("\tNumber of features: {n_features}", n_features=len(df_X.columns))
+    )
     logger.info("====================")
     logger.info("")
 
     if problem_type == "classification":
-        logger.info(f"\tNumber of classes: {len(np.unique(df_y))}")
-        logger.info(f"\tTarget type: {df_y.dtype}")
-        logger.info(f"\tClass distributions: {df_y.value_counts()}")
+        logger.info(
+            __(
+                "\tNumber of classes: {n_classes}",
+                n_classes=len(np.unique(df_y)),
+            )
+        )
+        logger.info(__("\tTarget type: {target_type}", target_type=df_y.dtype))
+        logger.info(
+            __(
+                "\tClass distributions: {class_distributions}",
+                class_distributions=df_y.value_counts(),
+            )
+        )
     elif problem_type == "regression":
-        logger.info(f"\tTarget type: {df_y.dtype}")
+        logger.info(__("\tTarget type: {target_type}", target_type=df_y.dtype))
 
     out = (
         df_X,

--- a/julearn/api.py
+++ b/julearn/api.py
@@ -578,7 +578,7 @@ def run_cross_validation(
         classifier=problem_type == "classification",
         include_final_model=include_final_model,
     )
-    logger.info(f"Using outer CV scheme {cv_outer}")
+    logger.info(__("Using outer CV scheme {cv_outer}", cv_outer=cv_outer))
 
     groups_needed = check_consistency(df_y, cv, groups, problem_type)  # type: ignore
 

--- a/julearn/config.py
+++ b/julearn/config.py
@@ -10,6 +10,7 @@ from .utils import logger, raise_error
 
 _global_config = {}
 _global_config["MAX_X_WARNS"] = 5000
+_global_config["max_x_logs"] = 100
 _global_config["disable_x_check"] = False
 _global_config["disable_xtypes_check"] = False
 _global_config["disable_x_verbose"] = False

--- a/julearn/config.py
+++ b/julearn/config.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from .utils import logger, raise_error
+from .utils.logging import DelayedFmtMessage as __
 
 
 _global_config = {}
@@ -32,7 +33,9 @@ def set_config(key: str, value: Any) -> None:
     """
     if key not in _global_config:
         raise_error(f"Global config {key} does not exist")
-    logger.info(f"Setting global config {key} to {value}")
+    logger.info(
+        __("Setting global config {key} to {value}", key=key, value=value)
+    )
     _global_config[key] = value
 
 

--- a/julearn/model_selection/_optuna_searcher.py
+++ b/julearn/model_selection/_optuna_searcher.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from ..utils import logger
+from ..utils.logging import DelayedFmtMessage as __
 from .available_searchers import _recreate_reset_copy, register_searcher
 
 
@@ -90,32 +91,53 @@ def _prepare_optuna_hyperparameters_distributions(
             if v[2] == "uniform":
                 if isinstance(v[0], int) and isinstance(v[1], int):
                     logger.info(
-                        f"Hyperparameter {k} is uniform integer "
-                        f"[{v[0]}, {v[1]}]"
+                        __(
+                            "Hyperparameter {k} is uniform integer "
+                            "[{v[0]}, {v[1]}]",
+                            k=k,
+                            v=v,
+                        )
                     )
                     out[k] = optd.IntDistribution(v[0], v[1], log=False)
                 else:
                     logger.info(
-                        f"Hyperparameter {k} is uniform float [{v[0]}, {v[1]}]"
+                        __(
+                            "Hyperparameter {k} is uniform float "
+                            "[{v[0]}, {v[1]}]",
+                            k=k,
+                            v=v,
+                        )
                     )
                     out[k] = optd.FloatDistribution(v[0], v[1], log=False)
             elif v[2] == "log-uniform":
                 if isinstance(v[0], int) and isinstance(v[1], int):
                     logger.info(
-                        f"Hyperparameter {k} is log-uniform int "
-                        f"[{v[0]}, {v[1]}]"
+                        __(
+                            "Hyperparameter {k} is log-uniform int "
+                            "[{v[0]}, {v[1]}]",
+                            k=k,
+                            v=v,
+                        )
                     )
                     out[k] = optd.IntDistribution(v[0], v[1], log=True)
                 else:
                     logger.info(
-                        f"Hyperparameter {k} is log-uniform float "
-                        f"[{v[0]}, {v[1]}]"
+                        __(
+                            "Hyperparameter {k} is log-uniform float "
+                            "[{v[0]}, {v[1]}]",
+                            k=k,
+                            v=v,
+                        )
                     )
                     out[k] = optd.FloatDistribution(v[0], v[1], log=True)
             elif v[2] == "categorical":
                 logger.info(
-                    f"Hyperparameter {k} is categorical with 2 "
-                    f"options: [{v[0]} and {v[1]}]"
+                    __(
+                        "Hyperparameter {k} is categorical with 2 "
+                        "options: [{v[0]} and {v[1]}]",
+                        k=k,
+                        v=v,
+                    )
                 )
                 out[k] = optd.CategoricalDistribution((v[0], v[1]))
             else:
@@ -125,9 +147,11 @@ def _prepare_optuna_hyperparameters_distributions(
             and isinstance(v[-1], str)
             and v[-1] == "categorical"
         ):
-            logger.info(f"Hyperparameter {k} is categorical [{v[:-1]}]")
+            logger.info(
+                __("Hyperparameter {k} is categorical [{v[:-1]}]", k=k, v=v)
+            )
             out[k] = optd.CategoricalDistribution(v[:-1])
         else:
-            logger.info(f"Hyperparameter {k} as is {v}")
+            logger.info(__("Hyperparameter {k} as is {v}", k=k, v=v))
             out[k] = v
     return out

--- a/julearn/model_selection/_optuna_searcher.py
+++ b/julearn/model_selection/_optuna_searcher.py
@@ -93,19 +93,20 @@ def _prepare_optuna_hyperparameters_distributions(
                     logger.info(
                         __(
                             "Hyperparameter {k} is uniform integer "
-                            "[{v[0]}, {v[1]}]",
+                            "[{v1}, {v2}]",
                             k=k,
-                            v=v,
+                            v1=v[0],
+                            v2=v[1],
                         )
                     )
                     out[k] = optd.IntDistribution(v[0], v[1], log=False)
                 else:
                     logger.info(
                         __(
-                            "Hyperparameter {k} is uniform float "
-                            "[{v[0]}, {v[1]}]",
+                            "Hyperparameter {k} is uniform float [{v1}, {v2}]",
                             k=k,
-                            v=v,
+                            v1=v[0],
+                            v2=v[1],
                         )
                     )
                     out[k] = optd.FloatDistribution(v[0], v[1], log=False)
@@ -114,9 +115,10 @@ def _prepare_optuna_hyperparameters_distributions(
                     logger.info(
                         __(
                             "Hyperparameter {k} is log-uniform int "
-                            "[{v[0]}, {v[1]}]",
+                            "[{v1}, {v2}]",
                             k=k,
-                            v=v,
+                            v1=v[0],
+                            v2=v[1],
                         )
                     )
                     out[k] = optd.IntDistribution(v[0], v[1], log=True)
@@ -124,9 +126,10 @@ def _prepare_optuna_hyperparameters_distributions(
                     logger.info(
                         __(
                             "Hyperparameter {k} is log-uniform float "
-                            "[{v[0]}, {v[1]}]",
+                            "[{v1}, {v2}]",
                             k=k,
-                            v=v,
+                            v1=v[0],
+                            v2=v[1],
                         )
                     )
                     out[k] = optd.FloatDistribution(v[0], v[1], log=True)
@@ -134,9 +137,10 @@ def _prepare_optuna_hyperparameters_distributions(
                 logger.info(
                     __(
                         "Hyperparameter {k} is categorical with 2 "
-                        "options: [{v[0]} and {v[1]}]",
+                        "options: [{v1} and {v2}]",
                         k=k,
-                        v=v,
+                        v1=v[0],
+                        v2=v[1],
                     )
                 )
                 out[k] = optd.CategoricalDistribution((v[0], v[1]))
@@ -148,7 +152,7 @@ def _prepare_optuna_hyperparameters_distributions(
             and v[-1] == "categorical"
         ):
             logger.info(
-                __("Hyperparameter {k} is categorical [{v[:-1]}]", k=k, v=v)
+                __("Hyperparameter {k} is categorical [{v}]", k=k, v=v[:-1])
             )
             out[k] = optd.CategoricalDistribution(v[:-1])
         else:

--- a/julearn/model_selection/_skopt_searcher.py
+++ b/julearn/model_selection/_skopt_searcher.py
@@ -68,28 +68,32 @@ def _prepare_skopt_hyperparameters_distributions(
                 logger.info(
                     __(
                         "Hyperparameter {k} is categorical with 2 "
-                        "options: [{v[0]} and {v[1]}]",
+                        "options: [{v1} and {v2}]",
                         k=k,
-                        v=v,
+                        v1=v[0],
+                        v2=v[1],
                     )
                 )
                 out[k] = sksp.Categorical(v[:-1])
             elif isinstance(v[0], int) and isinstance(v[1], int):
                 logger.info(
                     __(
-                        "Hyperparameter {k} is {prior} integer "
-                        "[{v[0]}, {v[1]}]",
+                        "Hyperparameter {k} is {prior} integer [{v1}, {v2}]",
                         k=k,
-                        v=v,
+                        prior=prior,
+                        v1=v[0],
+                        v2=v[1],
                     )
                 )
                 out[k] = sksp.Integer(v[0], v[1], prior=prior)
             elif isinstance(v[0], float) and isinstance(v[1], float):
                 logger.info(
                     __(
-                        "Hyperparameter {k} is {prior} float [{v[0]}, {v[1]}]",
+                        "Hyperparameter {k} is {prior} float [{v1}, {v2}]",
                         k=k,
-                        v=v,
+                        prior=prior,
+                        v1=v[0],
+                        v2=v[1],
                     )
                 )
                 out[k] = sksp.Real(v[0], v[1], prior=prior)

--- a/julearn/model_selection/_skopt_searcher.py
+++ b/julearn/model_selection/_skopt_searcher.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from ..utils import logger
+from ..utils.logging import DelayedFmtMessage as __
 from .available_searchers import _recreate_reset_copy, register_searcher
 
 
@@ -65,22 +66,35 @@ def _prepare_skopt_hyperparameters_distributions(
             prior = v[2]
             if prior == "categorical":
                 logger.info(
-                    f"Hyperparameter {k} is categorical with 2 "
-                    f"options: [{v[0]} and {v[1]}]"
+                    __(
+                        "Hyperparameter {k} is categorical with 2 "
+                        "options: [{v[0]} and {v[1]}]",
+                        k=k,
+                        v=v,
+                    )
                 )
                 out[k] = sksp.Categorical(v[:-1])
             elif isinstance(v[0], int) and isinstance(v[1], int):
                 logger.info(
-                    f"Hyperparameter {k} is {prior} integer [{v[0]}, {v[1]}]"
+                    __(
+                        "Hyperparameter {k} is {prior} integer "
+                        "[{v[0]}, {v[1]}]",
+                        k=k,
+                        v=v,
+                    )
                 )
                 out[k] = sksp.Integer(v[0], v[1], prior=prior)
             elif isinstance(v[0], float) and isinstance(v[1], float):
                 logger.info(
-                    f"Hyperparameter {k} is {prior} float [{v[0]}, {v[1]}]"
+                    __(
+                        "Hyperparameter {k} is {prior} float [{v[0]}, {v[1]}]",
+                        k=k,
+                        v=v,
+                    )
                 )
                 out[k] = sksp.Real(v[0], v[1], prior=prior)
             else:
-                logger.info(f"Hyperparameter {k} as is {v}")
+                logger.info(__("Hyperparameter {k} as is {v}", k=k, v=v))
                 out[k] = v
         elif (
             isinstance(v, tuple)
@@ -89,6 +103,6 @@ def _prepare_skopt_hyperparameters_distributions(
         ):
             out[k] = sksp.Categorical(v[:-1])
         else:
-            logger.info(f"Hyperparameter {k} as is {v}")
+            logger.info(__("Hyperparameter {k} as is {v}", k=k, v=v))
             out[k] = v
     return out

--- a/julearn/model_selection/available_searchers.py
+++ b/julearn/model_selection/available_searchers.py
@@ -9,7 +9,14 @@ from typing import Optional, Union
 
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 
-from julearn.utils.logging import logger, raise_error, warn_with_log
+from julearn.utils.logging import (
+    DelayedFmtMessage as __,
+)
+from julearn.utils.logging import (
+    logger,
+    raise_error,
+    warn_with_log,
+)
 
 
 _available_searchers = {
@@ -125,7 +132,12 @@ def register_searcher(
                 "Set `overwrite=True` in case you want to "
                 "overwrite existing searchers."
             )
-    logger.info(f"Registering new searcher: {searcher_name}")
+    logger.info(
+        __(
+            "Registering new searcher: {searcher_name}",
+            searcher_name=searcher_name,
+        )
+    )
     _available_searchers[searcher_name] = {
         "class": searcher,
         "params_attr": params_attr,

--- a/julearn/models/available_models.py
+++ b/julearn/models/available_models.py
@@ -47,6 +47,7 @@ from sklearn.naive_bayes import (
 from sklearn.svm import SVC, SVR
 
 from ..utils import logger, raise_error, warn_with_log
+from ..utils.logging import DelayedFmtMessage as __
 from ..utils.typing import ModelLike
 from .dynamic import DynamicSelection
 
@@ -256,15 +257,23 @@ def register_model(
                         )
 
                     logger.info(
-                        f"registering model named {model_name} "
-                        f"with problem_type {problem_type}"
+                        __(
+                            "registering model named {model_name} "
+                            "with problem_type {problem_type}",
+                            model_name=model_name,
+                            problem_type=problem_type,
+                        )
                     )
 
                 _available_models[model_name][problem_type] = cls
             else:
                 logger.info(
-                    f"registering model named {model_name} "
-                    f"with problem_type {problem_type}"
+                    __(
+                        "registering model named {model_name} "
+                        "with problem_type {problem_type}",
+                        model_name=model_name,
+                        problem_type=problem_type,
+                    )
                 )
                 _available_models[model_name] = {problem_type: cls}
 

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -37,6 +37,7 @@ from ..transformers.target import (
     JuTransformedTargetModel,
 )
 from ..utils import logger, raise_error, warn_with_log
+from ..utils.logging import DelayedFmtMessage as __
 from ..utils.typing import (
     EstimatorLike,
     JuEstimatorLike,
@@ -331,7 +332,13 @@ class PipelineCreator:
 
         # If the user did not give a name, we will create one.
         name = self._get_step_name(name, step)
-        logger.info(f"Adding step {name} that applies to {apply_to}")
+        logger.info(
+            __(
+                "Adding step {name} that applies to {apply_to}",
+                name=name,
+                apply_to=apply_to,
+            )
+        )
 
         # Find which parameters should be set and which should be tuned.
         params_to_set = {}
@@ -345,31 +352,63 @@ class PipelineCreator:
                 and not isinstance(vals, str)
             ):
                 if len(vals) > 1:
-                    logger.info(f"Tuning hyperparameter {param} = {vals}")
+                    logger.info(
+                        __(
+                            "Tuning hyperparameter {param} = {vals}",
+                            param=param,
+                            vals=vals,
+                        )
+                    )
                     params_to_tune[param] = vals
                 else:
-                    logger.info(f"Setting hyperparameter {param} = {vals[0]}")
+                    logger.info(
+                        __(
+                            "Setting hyperparameter {param} = {vals[0]}",
+                            param=param,
+                            vals=vals,
+                        )
+                    )
                     params_to_set[param] = vals[0]
             elif hasattr(vals, "rvs"):
                 # If it is a distribution, we will tune it.
-                logger.info(f"Tuning hyperparameter {param} = {vals}")
+                logger.info(
+                    __(
+                        "Tuning hyperparameter {param} = {vals}",
+                        param=param,
+                        vals=vals,
+                    )
+                )
                 params_to_tune[param] = vals
             elif is_optuna_valid_distribution(vals):
-                logger.info(f"Tuning hyperparameter {param} = {vals}")
+                logger.info(
+                    __(
+                        "Tuning hyperparameter {param} = {vals}",
+                        param=param,
+                        vals=vals,
+                    )
+                )
                 params_to_tune[param] = vals
             else:
-                logger.info(f"Setting hyperparameter {param} = {vals}")
+                logger.info(
+                    __(
+                        "Setting hyperparameter {param} = {vals}",
+                        param=param,
+                        vals=vals,
+                    )
+                )
                 params_to_set[param] = vals
 
         # Build the estimator for this step
         if isinstance(step, str):
             if step != "generate_target":
-                logger.debug(f"Getting estimator from string: {step}")
+                logger.debug(
+                    __("Getting estimator from string: {step}", step=step)
+                )
                 step = self._get_estimator_from(
                     step, self.problem_type, **params_to_set
                 )
             else:
-                logger.debug(f"Special step is {step}")
+                logger.debug(__("Special step is {step}", step=step))
                 name = "generate_target"
                 if len(apply_to & ColumnTypes("*")) > 0:
                     raise_error(
@@ -440,7 +479,7 @@ class PipelineCreator:
                 row_select_vals=row_select_vals,
             )
         )
-        logger.info("Step added")
+        logger.info(__("Step added"))
         return self
 
     @property
@@ -472,7 +511,7 @@ class PipelineCreator:
             The copy of the PipelineCreator
 
         """
-        logger.debug("Copying creator")
+        logger.debug(__("Copying creator"))
         other = PipelineCreator(
             problem_type=self.problem_type, apply_to=self.apply_to
         )
@@ -606,7 +645,7 @@ class PipelineCreator:
             The pipeline created from the PipelineCreator
 
         """
-        logger.debug("Creating pipeline")
+        logger.debug(__("Creating pipeline"))
         if not self.has_model() and not self.no_model_ok:
             raise_error("Cannot create a pipeline without a model")
         pipeline_steps: list[tuple[str, Any]] = [
@@ -616,7 +655,7 @@ class PipelineCreator:
         X_types = self._check_X_types(X_types)
         if self.no_model_ok and not self.has_model():
             model_step = None
-            logger.debug("Creating a pipeline with no model added")
+            logger.debug(__("Creating a pipeline with no model added"))
         else:
             model_step = self._steps[-1]
 
@@ -631,7 +670,7 @@ class PipelineCreator:
                 target_trans_step = _step
             elif _step.name == "generate_target":
                 target_trans_step = _step
-                logger.debug("Ensuring target generator pipeline")
+                logger.debug(__("Ensuring target generator pipeline"))
                 is_transformer = True
                 if isinstance(target_trans_step.estimator, PipelineCreator):
                     if target_trans_step.estimator.has_model():
@@ -648,7 +687,7 @@ class PipelineCreator:
                     X_types=X_types,
                     search_params=search_params,
                 )
-                logger.debug("Target generator pipeline created")
+                logger.debug(__("Target generator pipeline created"))
                 # logger.info("Dropping columns used to generate target")
                 # transformer_steps.append(
                 #     Step(
@@ -668,12 +707,17 @@ class PipelineCreator:
         # Add transformers
         params_to_tune = {}
         for step_dict in transformer_steps:
-            logger.debug(f"Adding transformer {step_dict.name}")
+            logger.debug(__("Adding transformer {name}", name=step_dict.name))
             name = step_dict.name
             estimator = step_dict.estimator
-            logger.debug(f"\t Estimator: {estimator}")
+            logger.debug(__("\t Estimator: {estimator}", estimator=estimator))
             step_params_to_tune = step_dict.params_to_tune
-            logger.debug(f"\t Params to tune: {step_params_to_tune}")
+            logger.debug(
+                __(
+                    "\t Params to tune: {step_params_to_tune}",
+                    step_params_to_tune=step_params_to_tune,
+                )
+            )
 
             # Wrap in a JuTransformer if needed
             if _should_wrap_this_step(
@@ -697,7 +741,9 @@ class PipelineCreator:
         if model_step is not None:
             model_name = model_step.name
             model_estimator = model_step.estimator
-            logger.debug(f"Adding model {model_name}")
+            logger.debug(
+                __("Adding model {model_name}", model_name=model_name)
+            )
 
             model_params = model_estimator.get_params(deep=False)
             model_params = {
@@ -710,16 +756,25 @@ class PipelineCreator:
             if _should_wrap_this_step(
                 X_types, model_step.apply_to
             ) and not isinstance(model_estimator, JuModelLike):
-                logger.debug(f"Wrapping {model_name}")
+                logger.debug(
+                    __("Wrapping {model_name}", model_name=model_name)
+                )
                 model_estimator = WrapModel(
                     model_estimator, model_step.apply_to
                 )
 
             step_params_to_tune = model_step.params_to_tune
 
-            logger.debug(f"\t Estimator: {model_estimator}")
-            logger.debug("\t Looking for nested pipeline creators")
-            logger.debug(f"\t Params to tune: {step_params_to_tune}")
+            logger.debug(
+                __("\t Estimator: {estimator}", estimator=model_estimator)
+            )
+            logger.debug(__("\t Looking for nested pipeline creators"))
+            logger.debug(
+                __(
+                    "\t Params to tune: {step_params_to_tune}",
+                    step_params_to_tune=step_params_to_tune,
+                )
+            )
             if self._added_target_transformer or self._added_target_generator:
                 # If we have a target transformer, we need to wrap the model
                 # in the right "Targeted" transformer.
@@ -728,7 +783,13 @@ class PipelineCreator:
                     if self._added_target_transformer
                     else "target_generate"
                 )
-                logger.debug(f"Wrapping target model {model_name} as {kind}")
+                logger.debug(
+                    __(
+                        "Wrapping target model {model_name} as {kind}",
+                        model_name=model_name,
+                        kind=kind,
+                    )
+                )
 
                 target_model_step = self._wrap_target_model(
                     model_name,
@@ -759,7 +820,7 @@ class PipelineCreator:
         out = _prepare_hyperparameter_tuning(
             params_to_tune, search_params, pipeline
         )
-        logger.debug("Pipeline created")
+        logger.debug(__("Pipeline created"))
         return out
 
     @staticmethod
@@ -1190,19 +1251,22 @@ def _prepare_hyperparameter_tuning(
             else:
                 warn_with_log(f"{search} is not a registered searcher. ")
                 logger.info(
-                    f"Tuning hyperparameters using not registered {search}"
+                    __(
+                        "Tuning hyperparameters using not registered {search}",
+                        search=search,
+                    )
                 )
 
         if isinstance(params_to_tune, dict):
             logger.info("Hyperparameters:")
             for k, v in params_to_tune.items():
-                logger.info(f"\t{k}: {v}")
+                logger.info(__("\t{k}: {v}", k=k, v=v))
         else:
             logger.info("Hyperparameters list:")
             for i_list, t_params in enumerate(params_to_tune):
-                logger.info(f"\tSet {i_list}")
+                logger.info(__("\tSet {i_list}", i_list=i_list))
                 for k, v in t_params.items():
-                    logger.info(f"\t\t{k}: {v}")
+                    logger.info(__("\t\t{k}: {v}", k=k, v=v))
 
         if search == RandomizedSearchCV:
             # If we are using RandomizedSearchCV, we can adopt the
@@ -1238,11 +1302,11 @@ def _prepare_hyperparameter_tuning(
                     for p in params_to_tune
                 ]
         cv_inner = check_cv(cv_inner)  # type: ignore
-        logger.info(f"Using inner CV scheme {cv_inner}")
+        logger.info(__("Using inner CV scheme {cv_inner}", cv_inner=cv_inner))
         search_params["cv"] = cv_inner
         logger.info("Search Parameters:")
         for k, v in search_params.items():
-            logger.info(f"\t{k}: {v}")
+            logger.info(__("\t{k}: {v}", k=k, v=v))
 
         # TODO: missing searcher typing
         pipeline = search(  # type: ignore

--- a/julearn/pipeline/pipeline_creator.py
+++ b/julearn/pipeline/pipeline_creator.py
@@ -479,7 +479,7 @@ class PipelineCreator:
                 row_select_vals=row_select_vals,
             )
         )
-        logger.info(__("Step added"))
+        logger.info("Step added")
         return self
 
     @property
@@ -511,7 +511,7 @@ class PipelineCreator:
             The copy of the PipelineCreator
 
         """
-        logger.debug(__("Copying creator"))
+        logger.debug("Copying creator")
         other = PipelineCreator(
             problem_type=self.problem_type, apply_to=self.apply_to
         )
@@ -645,7 +645,7 @@ class PipelineCreator:
             The pipeline created from the PipelineCreator
 
         """
-        logger.debug(__("Creating pipeline"))
+        logger.debug("Creating pipeline")
         if not self.has_model() and not self.no_model_ok:
             raise_error("Cannot create a pipeline without a model")
         pipeline_steps: list[tuple[str, Any]] = [
@@ -655,7 +655,7 @@ class PipelineCreator:
         X_types = self._check_X_types(X_types)
         if self.no_model_ok and not self.has_model():
             model_step = None
-            logger.debug(__("Creating a pipeline with no model added"))
+            logger.debug("Creating a pipeline with no model added")
         else:
             model_step = self._steps[-1]
 
@@ -670,7 +670,7 @@ class PipelineCreator:
                 target_trans_step = _step
             elif _step.name == "generate_target":
                 target_trans_step = _step
-                logger.debug(__("Ensuring target generator pipeline"))
+                logger.debug("Ensuring target generator pipeline")
                 is_transformer = True
                 if isinstance(target_trans_step.estimator, PipelineCreator):
                     if target_trans_step.estimator.has_model():
@@ -687,7 +687,7 @@ class PipelineCreator:
                     X_types=X_types,
                     search_params=search_params,
                 )
-                logger.debug(__("Target generator pipeline created"))
+                logger.debug("Target generator pipeline created")
                 # logger.info("Dropping columns used to generate target")
                 # transformer_steps.append(
                 #     Step(
@@ -820,7 +820,7 @@ class PipelineCreator:
         out = _prepare_hyperparameter_tuning(
             params_to_tune, search_params, pipeline
         )
-        logger.debug(__("Pipeline created"))
+        logger.debug("Pipeline created")
         return out
 
     @staticmethod
@@ -1236,7 +1236,9 @@ def _prepare_hyperparameter_tuning(
         cv_inner = search_params.get("cv", None)
 
         if search in list_searchers():
-            logger.info(f"Tuning hyperparameters using {search}")
+            logger.info(
+                __("Tuning hyperparameters using {search}", search=search)
+            )
             search = get_searcher(search)
         else:
             if isinstance(search, str):

--- a/julearn/prepare.py
+++ b/julearn/prepare.py
@@ -24,6 +24,7 @@ from .model_selection import (
     RepeatedContinuousStratifiedGroupKFold,
 )
 from .utils import logger, raise_error, warn_with_log
+from .utils.logging import DelayedFmtMessage as __
 from .utils.typing import CVLike
 
 
@@ -290,8 +291,11 @@ def prepare_input_data(
 
     # Validate the variables
     _validate_input_data_df(X, y, df, groups)
-    logger.info(f"\tFeatures: {X}")
-    logger.info(f"\tTarget: {y}")
+    if len(X) <= get_config("max_x_logs"):
+        logger.info(__("\tFeatures: {features}", features=X))
+    else:
+        logger.info(__("\tFeatures: {n_features} columns", n_features=len(X)))
+    logger.info(__("\tTarget: {target}", target=y))
 
     if not isinstance(X, list):
         X = [X]
@@ -304,7 +308,12 @@ def prepare_input_data(
         X_columns = _pick_columns(X, df.columns)
 
     if not get_config("disable_x_verbose"):
-        logger.info(f"\tExpanded features: {X_columns}")
+        logger.info(
+            __(
+                "\tExpanded features: {expanded_features}",
+                expanded_features=X_columns,
+            )
+        )
 
     _validate_input_data_df_ext(X_columns, y, df, groups)
 
@@ -324,7 +333,7 @@ def prepare_input_data(
 
     # Get groups
     if groups is not None:
-        logger.info(f"Using {groups} as groups")
+        logger.info(__("Using {groups} as groups"), groups=groups)
         df_groups = df.loc[:, groups].copy()
 
     # Convert the target to binary if pos_labels is not None
@@ -335,7 +344,10 @@ def prepare_input_data(
             )
         if not isinstance(pos_labels, list):
             pos_labels = [pos_labels]
-        logger.info(f"Setting the following as positive labels {pos_labels}")
+        logger.info(
+            __("Setting the following as positive labels {pos_labels}"),
+            pos_labels=pos_labels,
+        )
 
         not_in_labels = [x for x in pos_labels if x not in df_y.unique()]
         if len(not_in_labels) > 0:
@@ -418,8 +430,11 @@ def check_consistency(
             )
         if n_classes != 2:
             logger.info(
-                "Multi-class classification problem detected "
-                f"#classes = {n_classes}."
+                __(
+                    "Multi-class classification problem detected "
+                    "#classes = {n_classes}.",
+                    n_classes=n_classes,
+                )
             )
             if n_classes > (y.shape[0] / 2):
                 warn_with_log(
@@ -519,7 +534,7 @@ def _check_x_types(
         k: [v] if not isinstance(v, list) else v for k, v in X_types.items()
     }
     if not get_config("disable_xtypes_verbose"):
-        logger.info(f"\tX_types:{X_types}")
+        logger.info(__("\tX_types:{X_types}", X_types=X_types))
 
     skip_this_check = get_config("disable_xtypes_check")
     if not skip_this_check:

--- a/julearn/prepare.py
+++ b/julearn/prepare.py
@@ -333,7 +333,7 @@ def prepare_input_data(
 
     # Get groups
     if groups is not None:
-        logger.info(__("Using {groups} as groups"), groups=groups)
+        logger.info(__("Using {groups} as groups", groups=groups))
         df_groups = df.loc[:, groups].copy()
 
     # Convert the target to binary if pos_labels is not None
@@ -345,8 +345,10 @@ def prepare_input_data(
         if not isinstance(pos_labels, list):
             pos_labels = [pos_labels]
         logger.info(
-            __("Setting the following as positive labels {pos_labels}"),
-            pos_labels=pos_labels,
+            __(
+                "Setting the following as positive labels {pos_labels}",
+                pos_labels=pos_labels,
+            )
         )
 
         not_in_labels = [x for x in pos_labels if x not in df_y.unique()]

--- a/julearn/scoring/available_scorers.py
+++ b/julearn/scoring/available_scorers.py
@@ -20,6 +20,7 @@ from ..transformers.target.ju_transformed_target_model import (
     TransformedTargetWarning,
 )
 from ..utils import logger, raise_error, warn_with_log
+from ..utils.logging import DelayedFmtMessage as __
 from ..utils.typing import EstimatorLike, ScorerLike
 from .metrics import r2_corr, r_corr
 
@@ -116,7 +117,12 @@ def register_scorer(
                 f"Therefore, {scorer_name} will be overwritten. "
                 "To remove this warning set overwrite=True "
             )
-            logger.info(f"registering scorer named {scorer_name}")
+            logger.info(
+                __(
+                    "registering scorer named {scorer_name}",
+                    scorer_name=scorer_name,
+                )
+            )
         elif overwrite is False:
             raise_error(
                 f"scorer named {scorer_name} already exists and "
@@ -124,7 +130,9 @@ def register_scorer(
                 "existing scorers. Set overwrite=True in case you want to "
                 "overwrite existing scorers"
             )
-    logger.info(f"registering scorer named {scorer_name}")
+    logger.info(
+        __("registering scorer named {scorer_name}", scorer_name=scorer_name)
+    )
     _extra_available_scorers[scorer_name] = scorer
 
 
@@ -155,7 +163,11 @@ def check_scoring(
     if scoring is None:
         return scoring
     logger.debug(
-        f"Checking scoring{' (wrapping)' if wrap_score else ''}: [{scoring}]"
+        __(
+            "Checking scoring{score}: [{scoring}]",
+            score=" (wrapping)" if wrap_score else "",
+            scoring=scoring,
+        )
     )
     if isinstance(scoring, str):
         scoring = _extend_scorer(get_scorer(scoring), wrap_score)

--- a/julearn/transformers/available_transformers.py
+++ b/julearn/transformers/available_transformers.py
@@ -28,6 +28,7 @@ from sklearn.preprocessing import (
 )
 
 from ..utils import logger, raise_error, warn_with_log
+from ..utils.logging import DelayedFmtMessage as __
 from ..utils.typing import TransformerLike
 from .cbpm import CBPM
 from .confound_remover import ConfoundRemover
@@ -155,7 +156,12 @@ def register_transformer(transformer_name, transformer_cls, overwrite=None):
                 "in case you want to overwrite an existing transformer."
             )
 
-    logger.info(f"registering transformer named {transformer_name}.")
+    logger.info(
+        __(
+            "registering transformer named {transformer_name}.",
+            transformer_name=transformer_name,
+        )
+    )
 
     _available_transformers[transformer_name] = transformer_cls
 

--- a/julearn/transformers/dataframe/drop_columns.py
+++ b/julearn/transformers/dataframe/drop_columns.py
@@ -13,6 +13,7 @@ from sklearn.base import check_is_fitted
 
 from ...base import ColumnTypesLike, JuTransformer
 from ...utils import logger
+from ...utils.logging import DelayedFmtMessage as __
 from ...utils.typing import DataLike
 
 
@@ -93,7 +94,7 @@ class DropColumns(JuTransformer):
             Data with dropped columns.
 
         """
-        logger.debug(f"Dropping columns: {self.drop_columns_}")
+        logger.debug(__("Dropping columns: {cols}", cols=self.drop_columns_))
         return X.drop(columns=self.drop_columns_)
 
     def get_support(

--- a/julearn/transformers/dataframe/pick_columns.py
+++ b/julearn/transformers/dataframe/pick_columns.py
@@ -15,6 +15,7 @@ from ...base import (
     JuTransformer,
 )
 from ...utils import logger, raise_error
+from ...utils.logging import DelayedFmtMessage as __
 from ...utils.typing import DataLike
 
 
@@ -106,7 +107,7 @@ class PickColumns(JuTransformer):
             Data with dropped columns.
 
         """
-        logger.debug(f"Picking columns: {self.keep_columns_}")
+        logger.debug(__("Picking columns: {cols}", cols=self.keep_columns_))
         if len(self.keep_columns_) == 1:
             out = X[self.keep_columns_[0]]
         else:

--- a/julearn/transformers/dataframe/set_column_types.py
+++ b/julearn/transformers/dataframe/set_column_types.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from ...base import ColumnTypesLike, JuTransformer, change_column_type
 from ...utils import logger, raise_error
+from ...utils.logging import DelayedFmtMessage as __
 from ...utils.typing import DataLike
 
 
@@ -85,7 +86,12 @@ class SetColumnTypes(JuTransformer):
             X.columns = X.columns.astype(str)
 
         self.feature_names_in_ = X.columns
-        logger.debug(f"Setting column types for {self.feature_names_in_}")
+        logger.debug(
+            __(
+                "Setting column types for {features}",
+                features=self.feature_names_in_,
+            )
+        )
 
         # initialize the column_mapper_ using the X_types of X
         column_mapper_ = {}
@@ -109,7 +115,9 @@ class SetColumnTypes(JuTransformer):
                 {col: change_column_type(col, X_type) for col in t_columns}
             )
 
-        logger.debug(f"\tColumn mappers for {column_mapper_}")
+        logger.debug(
+            __("\tColumn mappers for {mapper}", mapper=column_mapper_)
+        )
         self.column_mapper_ = column_mapper_
         return self
 

--- a/julearn/transformers/target/available_target_transformers.py
+++ b/julearn/transformers/target/available_target_transformers.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import Any, Optional
 
 from ...utils import logger, raise_error, warn_with_log
+from ...utils.logging import DelayedFmtMessage as __
 from .ju_target_transformer import JuTargetTransformer
 from .target_confound_remover import TargetConfoundRemover
 
@@ -110,7 +111,9 @@ def register_target_transformer(
                 "transformer."
             )
 
-    logger.info(f"registering transformer named {transformer_name}.")
+    logger.info(
+        __("registering transformer named {name}.", name=transformer_name)
+    )
 
     _available_target_transformers[transformer_name] = transformer_cls
 

--- a/julearn/transformers/target/ju_generated_target_model.py
+++ b/julearn/transformers/target/ju_generated_target_model.py
@@ -14,6 +14,7 @@ from sklearn.utils.metaestimators import available_if
 
 from ...base import JuBaseEstimator
 from ...utils import logger, raise_error, warn_with_log
+from ...utils.logging import DelayedFmtMessage as __
 from ...utils.typing import DataLike, EstimatorLike, JuEstimatorLike, ModelLike
 
 
@@ -241,9 +242,9 @@ class JuGeneratedTargetModel(JuBaseEstimator):
         # If it's a pandas dataframe convert to series
         if gen_y.shape[1] == 1:
             gen_y = gen_y.iloc[:, 0]
-            logger.debug(f"Target generated: {gen_y.name}")
+            logger.debug(__("Target generated: {name}", name=gen_y.name))
         else:
-            logger.debug(f"Target generated: {gen_y.columns}")
+            logger.debug(__("Target generated: {name}", name=gen_y.columns))
         return gen_y
 
     @property

--- a/julearn/utils/logging.py
+++ b/julearn/utils/logging.py
@@ -96,7 +96,7 @@ def _safe_log(versions: dict, name: str) -> None:
 
     """
     if name in versions:
-        logger.info(f"{name}: {versions[name]}")
+        logger.info(DelayedFmtMessage("{name}: {versions[name]}", name=name))
 
 
 def log_versions() -> None:

--- a/julearn/utils/logging.py
+++ b/julearn/utils/logging.py
@@ -250,6 +250,38 @@ def warn_with_log(msg: str, category: type[Warning] = RuntimeWarning) -> None:
     warnings.warn(msg, category=category, stacklevel=2)
 
 
+class DelayedFmtMessage:
+    """Class for delayed formatting of log messages.
+
+    This is useful for cases where the log message is expensive to compute and
+    the logging level is such that the message would not be printed. In this
+    case, the message will only be computed if it is actually going to be
+    printed.
+
+    """
+
+    def __init__(self, fmt: str, *args: object, **kwargs: object) -> None:
+        """Initialize DelayedFmtMessage.
+
+        Parameters
+        ----------
+        fmt : str
+            The format string for the log message.
+        *args : object
+            The arguments to format into the log message.
+        **kwargs : object
+            The keyword arguments to format into the log message.
+
+        """
+        self.fmt = fmt
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self) -> str:
+        """Format the log message."""
+        return self.fmt.format(*self.args, **self.kwargs)
+
+
 class WrapStdOut(logging.StreamHandler):
     """Dynamically wrap to sys.stdout.
 

--- a/julearn/utils/logging.py
+++ b/julearn/utils/logging.py
@@ -96,7 +96,11 @@ def _safe_log(versions: dict, name: str) -> None:
 
     """
     if name in versions:
-        logger.info(DelayedFmtMessage("{name}: {versions[name]}", name=name))
+        logger.info(
+            DelayedFmtMessage(
+                "{name}: {version}", name=name, version=versions[name]
+            )
+        )
 
 
 def log_versions() -> None:


### PR DESCRIPTION
Currently, we have quite some calls to `logger.debug` and `logger.info` that print large messages, like this:

```
logger.info(f"Features: {X}")
```

The problem is that first the message is formatted and then the logging level is checked.

This PR introduces a mechanism to delay message formatting until the moment they are needed.